### PR TITLE
Force rewind in __toString() method

### DIFF
--- a/src/Stream/ResourceStream.php
+++ b/src/Stream/ResourceStream.php
@@ -62,6 +62,10 @@ class ResourceStream implements StreamInterface
      */
     public function __toString(): string
     {
+		if ($this->isSeekable()) {
+			$this->rewind();
+		}
+
         return $this->getContents();
 	}
 


### PR DESCRIPTION
We respect the PSR that MUST attempt to seek to the beginning of the stream before reading data.