### PR TITLE
2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+.vscode/
 .idea/
 vendor/
 build/
 tests/tmp
 composer.lock
 .phpunit.result.cache
+test.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 php:
-  - '7.3'
-  - '7.4'
-  - '8.0'
+  - 8.0
+  - 8.1
 
 install:
   - composer install

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 nimbly.io
+Copyright (c) 2022 nimbly.io
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ test:
 	vendor/bin/phpunit
 
 coverage:
-	vendor/bin/phpunit --coverage-clover=build/logs/clover.xml
+	php -d xdebug.mode=coverage vendor/bin/phpunit --coverage-clover=build/logs/clover.xml
 
 analyze:
 	vendor/bin/psalm

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ $response = $httpClient->sendRequest($request);
 
 ### ServerRequest
 
-The `ServerRequest` object represents an *incoming* HTTP request into your application, to be used with a PSR-7 compliant HTTP framework.
+The `ServerRequest` object represents an *incoming* HTTP request into your application, to be used with a PSR-7 compliant HTTP framework or other library.
 
 ```php
 $serverRequest = new ServerRequest("get", "https://example.org/books");
 
-$response = $application->dispatch($serverRequest);
+$response = $framework->dispatch($serverRequest);
 ```
 
 #### Creating from globals
@@ -41,7 +41,7 @@ Typically, you will want to create a `ServerRequest` instance from the PHP globa
 ```php
 $serverRequest = ServerRequestFactory::createFromGlobals();
 
-$response = $application->dispatch($serverRequest);
+$response = $framework->dispatch($serverRequest);
 ```
 #### Helpers
 
@@ -50,44 +50,44 @@ The `ServerRequest` instance offers helpers to test for and access various reque
 #### Parsed body helpers
 
 ```php
-if( $serverRequest->hasParsedBodyParam('foo') ){
+if( $serverRequest->hasBodyParam("foo") ){
 	// Do the foo...
 }
 
 /**
  * Get a single param ("bar") from the parsed body.
  */
-$bar = $serverRequest->getParsedBodyParam('bar');
+$bar = $serverRequest->getBodyParam("bar");
 
 /**
  * Get *only* the provided params from the parsed body.
  */
-$serverRequest->onlyBodyParams(['foo', 'bar']);
+$serverRequest->onlyBodyParams(["foo", "bar"]);
 
 /**
  * Get all params from the parsed body *except* those provided.
  */
-$serverRequest->exceptParsedBodyParams(['foo', 'bar']);
+$serverRequest->exceptBodyParams(["foo", "bar"]);
 ```
 
 #### Query param helpers
 
 ```php
-if( $serverRequest->hasQueryParam('foo') ){
+if( $serverRequest->hasQueryParam("foo") ){
 	// Do the foo...
 }
 
-$foo = $serverRequest->getQueryParam('foo');
+$foo = $serverRequest->getQueryParam("foo");
 ```
 
 #### Uploaded file helpers
 
 ```php
-if( $serverRequest->hasUploadedFile('avatar') ){
+if( $serverRequest->hasUploadedFile("avatar") ){
 	// Do something
 }
 
-$avatar = $serverRequest->getUploadedFile('avatar');
+$avatar = $serverRequest->getUploadedFile("avatar");
 ```
 
 ### Response
@@ -95,9 +95,25 @@ $avatar = $serverRequest->getUploadedFile('avatar');
 The `Response` object represents an HTTP response to either a `Request` or a `ServerRequest` action.
 
 ```php
-$response = new Response(200, \json_encode(["foo" => "bar"]), ['Content-Type' => 'application/json']);
+$response = new Response(200, \json_encode(["foo" => "bar"]), ["Content-Type" => "application/json"]);
+```
+
+### Response Status
+
+Capsule provides a `ResponseStatus` helper class with HTTP response codes as constants and reason phrases.
+
+```php
+$response = new Response(ResponseStatus::NOT_FOUND);
+```
+
+```php
+$phrase = ResponseStatus::getPhrase(ResonseStatus::NOT_FOUND);
+
+echo $phrase; // Outputs "Not Found"
 ```
 
 ## HTTP Factory (PSR-17)
 
 Capsule includes a set of PSR-17 factory classes to be used to create `Request`, `ServerRequest`,  `Response`, `Stream`, `UploadedFile`, and `Uri` instances.
+
+`RequestFactory`, `ServerRequestFactory`, `ResponseFactory`, `StreamFactory`, `UploadedFileFactory`, and `UriFactory`.

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,14 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.0",
         "psr/http-message": "^1.0",
-        "psr/http-factory": "^1.0"
+		"psr/http-factory": "^1.0"
     },
+	"provide": {
+		"psr/http-message-implementation": "^1.0",
+		"psr/http-factory-implementation": "^1.0"
+	},
 	"autoload": {
         "psr-4": {
             "Nimbly\\Capsule\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
         }
     ],
     "require": {
-        "php": ">=7.3|^8.0",
+        "php": "^8.1",
         "psr/http-message": "^1.0",
         "psr/http-factory": "^1.0"
     },
 	"autoload": {
         "psr-4": {
-            "Capsule\\": "src/"
+            "Nimbly\\Capsule\\": "src/"
         }
     },
     "require-dev": {
@@ -27,7 +27,7 @@
     },
 	"autoload-dev": {
         "psr-4": {
-            "Capsule\\Tests\\": "tests/"
+            "Nimbly\\Capsule\\Tests\\": "tests/"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,37 +1,37 @@
 {
-    "name": "nimbly/capsule",
-    "description": "Capsule is a simple PSR-7 HTTP message and PSR-17 HTTP factory implementation.",
-    "type": "library",
+	"name": "nimbly/capsule",
+	"description": "Capsule is a simple PSR-7 HTTP message and PSR-17 HTTP factory implementation.",
+	"type": "library",
 	"license": "MIT",
-    "authors": [
-        {
-            "name": "Brent Scheffler",
-            "email": "brent@brentscheffler.com"
-        }
-    ],
-    "require": {
-        "php": "^8.0",
-        "psr/http-message": "^1.0",
+	"authors": [
+		{
+			"name": "Brent Scheffler",
+			"email": "brent@brentscheffler.com"
+		}
+	],
+	"require": {
+		"php": "^8.0",
+		"psr/http-message": "^1.0",
 		"psr/http-factory": "^1.0"
-    },
+	},
 	"provide": {
 		"psr/http-message-implementation": "^1.0",
 		"psr/http-factory-implementation": "^1.0"
 	},
 	"autoload": {
-        "psr-4": {
-            "Nimbly\\Capsule\\": "src/"
-        }
-    },
-    "require-dev": {
-        "vimeo/psalm": "^4.0",
-        "phpunit/phpunit": "^9.0",
-        "php-coveralls/php-coveralls": "^2.4",
-        "symfony/var-dumper": "^4.3"
-    },
+		"psr-4": {
+			"Nimbly\\Capsule\\": "src/"
+		}
+	},
+	"require-dev": {
+		"vimeo/psalm": "^4.0",
+		"phpunit/phpunit": "^9.0",
+		"php-coveralls/php-coveralls": "^2.4",
+		"symfony/var-dumper": "^4.3"
+	},
 	"autoload-dev": {
-        "psr-4": {
-            "Nimbly\\Capsule\\Tests\\": "tests/"
-        }
-    }
+		"psr-4": {
+			"Nimbly\\Capsule\\Tests\\": "tests/"
+		}
+	}
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" executionOrder="depends,defects" forceCoversAnnotation="true" beStrictAboutCoversAnnotation="true" beStrictAboutOutputDuringTests="true" beStrictAboutTodoAnnotatedTests="true" verbose="true" colors="true">
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+	bootstrap="tests/bootstrap.php"
+	executionOrder="depends,defects"
+	forceCoversAnnotation="true"
+	beStrictAboutCoversAnnotation="true"
+	beStrictAboutOutputDuringTests="true"
+	beStrictAboutTodoAnnotatedTests="true"
+	verbose="true"
+	colors="true">
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">src</directory>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="3"
+    errorLevel="2"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="2"
+    errorLevel="3"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/src/Factory/RequestFactory.php
+++ b/src/Factory/RequestFactory.php
@@ -1,8 +1,8 @@
-<?php declare(strict_types=1);
+<?php
 
-namespace Capsule\Factory;
+namespace Nimbly\Capsule\Factory;
 
-use Capsule\Request;
+use Nimbly\Capsule\Request;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 

--- a/src/Factory/ResponseFactory.php
+++ b/src/Factory/ResponseFactory.php
@@ -1,8 +1,8 @@
-<?php declare(strict_types=1);
+<?php
 
-namespace Capsule\Factory;
+namespace Nimbly\Capsule\Factory;
 
-use Capsule\Response;
+use Nimbly\Capsule\Response;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -11,7 +11,7 @@ class ResponseFactory implements ResponseFactoryInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface
+	public function createResponse(int $code = 200, string $reasonPhrase = ""): ResponseInterface
 	{
 		return new Response($code, null, [], $reasonPhrase);
 	}

--- a/src/Factory/ServerRequestFactory.php
+++ b/src/Factory/ServerRequestFactory.php
@@ -1,9 +1,9 @@
-<?php declare(strict_types=1);
+<?php
 
-namespace Capsule\Factory;
+namespace Nimbly\Capsule\Factory;
 
-use Capsule\Factory\UploadedFileFactory;
-use Capsule\ServerRequest;
+use Nimbly\Capsule\Factory\UploadedFileFactory;
+use Nimbly\Capsule\ServerRequest;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -53,14 +53,14 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
 	public static function createFromGlobals(): ServerRequest
 	{
 		// Build out the URI
-		$scheme = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' ? "https" : "http";
+		$scheme = isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] !== "off" ? "https" : "http";
 
 		$uri = $scheme . "://" .
-		($_SERVER['HTTP_HOST'] ?? (($_SERVER['SERVER_NAME'] ?? "") . ":" . ($_SERVER['SERVER_PORT'] ?? ""))) .
-		($_SERVER['REQUEST_URI'] ?? "/");
+		($_SERVER["HTTP_HOST"] ?? (($_SERVER["SERVER_NAME"] ?? "") . ":" . ($_SERVER["SERVER_PORT"] ?? ""))) .
+		($_SERVER["REQUEST_URI"] ?? "/");
 
 		// Capture the version.
-		\preg_match("/^HTTP\/([\d\.]+)$/i", $_SERVER['SERVER_PROTOCOL'] ?? "", $versionMatch);
+		\preg_match("/^HTTP\/([\d\.]+)$/i", $_SERVER["SERVER_PROTOCOL"] ?? "", $versionMatch);
 
 		// Get the request body first by getting raw input from php://input.
 		$body = \file_get_contents("php://input");
@@ -71,10 +71,10 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
 			$files[$name] = UploadedFileFactory::createFromGlobal($file);
 		}
 
-		return new ServerRequest(
-			$_SERVER['REQUEST_METHOD'],
+		$serverRequest = new ServerRequest(
+			$_SERVER["REQUEST_METHOD"],
 			$uri,
-			!empty($body) ? $body : $_POST,
+			!empty($body) ? $body : null,
 			$_GET,
 			\array_change_key_case(\getallheaders()),
 			$_COOKIE,
@@ -82,5 +82,11 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
 			$_SERVER,
 			$versionMatch[2] ?? "1.1"
 		);
+
+		if( empty($body) ){
+			$serverRequest = $serverRequest->withParsedBody($_POST);
+		}
+
+		return $serverRequest;
 	}
 }

--- a/src/Factory/ServerRequestFactory.php
+++ b/src/Factory/ServerRequestFactory.php
@@ -67,12 +67,19 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
 
 		// Process the uploaded files into an array<UploadedFile>.
 		$files = [];
+
+		/**
+		 * @var array<string,array{error:int,name:string,size:int,tmp_name:string,type:string}> $_FILES
+		 */
 		foreach( $_FILES as $name => $file ){
 			$files[$name] = UploadedFileFactory::createFromGlobal($file);
 		}
 
+		/**
+		 * @psalm-suppress InvalidScalarArgument
+		 */
 		$serverRequest = new ServerRequest(
-			$_SERVER["REQUEST_METHOD"],
+			$_SERVER["REQUEST_METHOD"] ?? "GET",
 			$uri,
 			!empty($body) ? $body : null,
 			$_GET,

--- a/src/Factory/ServerRequestFactory.php
+++ b/src/Factory/ServerRequestFactory.php
@@ -81,7 +81,7 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
 		$serverRequest = new ServerRequest(
 			$_SERVER["REQUEST_METHOD"] ?? "GET",
 			$uri,
-			!empty($body) ? $body : null,
+			$body ?: null,
 			$_GET,
 			\array_change_key_case(\getallheaders()),
 			$_COOKIE,

--- a/src/Factory/StreamFactory.php
+++ b/src/Factory/StreamFactory.php
@@ -18,7 +18,7 @@ class StreamFactory implements StreamFactoryInterface
 		$fh = \fopen("php://temp", "w+");
 
 		if( $fh === false ){
-			throw new RuntimeException("Unable to create stream from php://temp");
+			throw new RuntimeException("Failed to create stream from php://temp.");
 		}
 
 		$stream = new ResourceStream($fh);
@@ -37,7 +37,7 @@ class StreamFactory implements StreamFactoryInterface
 		$fh = \fopen($filename, $mode);
 
 		if( $fh === false ){
-			throw new RuntimeException("Cannot open file.");
+			throw new RuntimeException("Failed to open file for reading.");
 		}
 
 		return new ResourceStream($fh);

--- a/src/Factory/StreamFactory.php
+++ b/src/Factory/StreamFactory.php
@@ -1,8 +1,9 @@
-<?php declare(strict_types=1);
+<?php
 
-namespace Capsule\Factory;
+namespace Nimbly\Capsule\Factory;
 
-use Capsule\Stream\ResourceStream;
+use Nimbly\Capsule\Stream\BufferStream;
+use Nimbly\Capsule\Stream\ResourceStream;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
@@ -12,7 +13,7 @@ class StreamFactory implements StreamFactoryInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function createStream(string $content = ''): StreamInterface
+	public function createStream(string $content = ""): StreamInterface
 	{
 		$fh = @\fopen("php://temp", "w+");
 
@@ -31,7 +32,7 @@ class StreamFactory implements StreamFactoryInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
+	public function createStreamFromFile(string $filename, string $mode = "r"): StreamInterface
 	{
 		$fh = @\fopen($filename, $mode);
 
@@ -48,5 +49,16 @@ class StreamFactory implements StreamFactoryInterface
 	public function createStreamFromResource($resource): StreamInterface
 	{
 		return new ResourceStream($resource);
+	}
+
+	/**
+	 * Create a BufferStream from a string.
+	 *
+	 * @param string $contents
+	 * @return StreamInterface
+	 */
+	public static function createFromString(string $contents): StreamInterface
+	{
+		return new BufferStream($contents);
 	}
 }

--- a/src/Factory/StreamFactory.php
+++ b/src/Factory/StreamFactory.php
@@ -34,13 +34,7 @@ class StreamFactory implements StreamFactoryInterface
 	 */
 	public function createStreamFromFile(string $filename, string $mode = "r"): StreamInterface
 	{
-		$fh = \fopen($filename, $mode);
-
-		if( $fh === false ){
-			throw new RuntimeException("Failed to open file for reading.");
-		}
-
-		return new ResourceStream($fh);
+		return self::createFromFile($filename, $mode);
 	}
 
 	/**
@@ -60,5 +54,34 @@ class StreamFactory implements StreamFactoryInterface
 	public static function createFromString(string $contents): StreamInterface
 	{
 		return new BufferStream($contents);
+	}
+
+	/**
+	 * Create a StreamInterface instance from a file.
+	 *
+	 * @param string $filename
+	 * @param string $mode
+	 * @return StreamInterface
+	 */
+	public static function createFromFile(string $filename, string $mode = "w+"): StreamInterface
+	{
+		$fh = \fopen($filename, $mode);
+
+		if( $fh === false ){
+			throw new RuntimeException("Failed to open file for reading.");
+		}
+
+		return new ResourceStream($fh);
+	}
+
+	/**
+	 * Create a StreamInterface instance from a resource.
+	 *
+	 * @param resource $resource
+	 * @return StreamInterface
+	 */
+	public static function createFromResource($resource): StreamInterface
+	{
+		return new ResourceStream($resource);
 	}
 }

--- a/src/Factory/StreamFactory.php
+++ b/src/Factory/StreamFactory.php
@@ -15,9 +15,9 @@ class StreamFactory implements StreamFactoryInterface
 	 */
 	public function createStream(string $content = ""): StreamInterface
 	{
-		$fh = @\fopen("php://temp", "w+");
+		$fh = \fopen("php://temp", "w+");
 
-		if( empty($fh) ){
+		if( $fh === false ){
 			throw new RuntimeException("Unable to create stream from php://temp");
 		}
 
@@ -34,9 +34,9 @@ class StreamFactory implements StreamFactoryInterface
 	 */
 	public function createStreamFromFile(string $filename, string $mode = "r"): StreamInterface
 	{
-		$fh = @\fopen($filename, $mode);
+		$fh = \fopen($filename, $mode);
 
-		if( empty($fh) ){
+		if( $fh === false ){
 			throw new RuntimeException("Cannot open file.");
 		}
 

--- a/src/Factory/UploadedFileFactory.php
+++ b/src/Factory/UploadedFileFactory.php
@@ -43,7 +43,7 @@ class UploadedFileFactory implements UploadedFileFactoryInterface
 		$fh = \fopen($file["tmp_name"], "r");
 
 		if( $fh === false ){
-			throw new RuntimeException("Failed to open file upload for reading.");
+			throw new RuntimeException("Failed to open file for reading.");
 		}
 
 		return new UploadedFile(

--- a/src/Factory/UploadedFileFactory.php
+++ b/src/Factory/UploadedFileFactory.php
@@ -2,7 +2,6 @@
 
 namespace Nimbly\Capsule\Factory;
 
-use Nimbly\Capsule\Stream\ResourceStream;
 use Nimbly\Capsule\UploadedFile;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileFactoryInterface;

--- a/src/Factory/UploadedFileFactory.php
+++ b/src/Factory/UploadedFileFactory.php
@@ -1,11 +1,13 @@
-<?php declare(strict_types=1);
+<?php
 
-namespace Capsule\Factory;
+namespace Nimbly\Capsule\Factory;
 
-use Capsule\UploadedFile;
+use Nimbly\Capsule\Stream\ResourceStream;
+use Nimbly\Capsule\UploadedFile;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileFactoryInterface;
 use Psr\Http\Message\UploadedFileInterface;
+use RuntimeException;
 
 class UploadedFileFactory implements UploadedFileFactoryInterface
 {
@@ -15,7 +17,7 @@ class UploadedFileFactory implements UploadedFileFactoryInterface
 	public function createUploadedFile(
         StreamInterface $stream,
         int $size = null,
-        int $error = \UPLOAD_ERR_OK,
+        int $error = UPLOAD_ERR_OK,
         string $clientFilename = null,
         string $clientMediaType = null
     ): UploadedFileInterface {
@@ -32,17 +34,23 @@ class UploadedFileFactory implements UploadedFileFactoryInterface
 	/**
 	 * Create an UploadedFile instance from a single $_FILES element.
 	 *
-	 * @param array $file
+	 * @param array{tmp_name:string,name:string,type:string,size:int,error:int} $file
 	 * @return UploadedFile
 	 */
 	public static function createFromGlobal(array $file): UploadedFile
 	{
+		$fh = \fopen($file["tmp_name"], "r");
+
+		if( $fh === false ){
+			throw new RuntimeException("Failed to open file for reading.");
+		}
+
 		return new UploadedFile(
-			$file['tmp_name'] ?? "",
-			$file['name'] ?? null,
-			$file['type'] ?? null,
-			(int) ($file['size'] ?? 0),
-			(int) ($file['error'] ?? UPLOAD_ERR_OK)
+			new ResourceStream($fh),
+			$file["name"] ?? null,
+			$file["type"] ?? null,
+			$file["size"] ?? 0,
+			$file["error"] ?? UPLOAD_ERR_OK
 		);
 	}
 }

--- a/src/Factory/UploadedFileFactory.php
+++ b/src/Factory/UploadedFileFactory.php
@@ -35,6 +35,7 @@ class UploadedFileFactory implements UploadedFileFactoryInterface
 	 * Create an UploadedFile instance from a single $_FILES element.
 	 *
 	 * @param array{tmp_name:string,name:string,type:string,size:int,error:int} $file
+	 * @throws RuntimeException
 	 * @return UploadedFile
 	 */
 	public static function createFromGlobal(array $file): UploadedFile
@@ -42,7 +43,7 @@ class UploadedFileFactory implements UploadedFileFactoryInterface
 		$fh = \fopen($file["tmp_name"], "r");
 
 		if( $fh === false ){
-			throw new RuntimeException("Failed to open file for reading.");
+			throw new RuntimeException("Failed to open file upload for reading.");
 		}
 
 		return new UploadedFile(

--- a/src/Factory/UploadedFileFactory.php
+++ b/src/Factory/UploadedFileFactory.php
@@ -40,14 +40,8 @@ class UploadedFileFactory implements UploadedFileFactoryInterface
 	 */
 	public static function createFromGlobal(array $file): UploadedFile
 	{
-		$fh = \fopen($file["tmp_name"], "r");
-
-		if( $fh === false ){
-			throw new RuntimeException("Failed to open file for reading.");
-		}
-
 		return new UploadedFile(
-			new ResourceStream($fh),
+			$file["tmp_name"],
 			$file["name"] ?? null,
 			$file["type"] ?? null,
 			$file["size"] ?? 0,

--- a/src/Factory/UriFactory.php
+++ b/src/Factory/UriFactory.php
@@ -1,8 +1,8 @@
-<?php declare(strict_types=1);
+<?php
 
-namespace Capsule\Factory;
+namespace Nimbly\Capsule\Factory;
 
-use Capsule\Uri;
+use Nimbly\Capsule\Uri;
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 use RuntimeException;
@@ -12,7 +12,7 @@ class UriFactory implements UriFactoryInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function createUri(string $uri = ''): UriInterface
+	public function createUri(string $uri = ""): UriInterface
 	{
 		return self::createFromString($uri);
 	}
@@ -33,13 +33,15 @@ class UriFactory implements UriFactoryInterface
 			throw new RuntimeException("Malformed URL string.");
 		}
 
-		return (new Uri)
-			->withScheme(!empty($uriPart['scheme']) ? \strtolower($uriPart['scheme']) : "http")
-			->withUserInfo($uriPart['user'] ?? "", $uriPart['pass'] ?? "")
-			->withHost(!empty($uriPart['host']) ? \strtolower($uriPart['host']) : "")
-			->withPort(!empty($uriPart['port']) ? $uriPart['port'] : null)
-			->withPath($uriPart['path'] ?? "")
-			->withQuery($uriPart['query'] ?? "")
-			->withFragment($uriPart['fragment'] ?? "");
+		return new Uri(
+			!empty($uriPart["scheme"]) ? \strtolower($uriPart["scheme"]) : "http",
+			!empty($uriPart["host"]) ? \strtolower($uriPart["host"]) : "",
+			$uriPart["path"] ?? "",
+			!empty($uriPart["port"]) ? $uriPart["port"] : null,
+			$uriPart["user"] ?? "",
+			$uriPart["pass"] ?? "",
+			$uriPart["query"] ?? "",
+			$uriPart["fragment"] ?? ""
+		);
 	}
 }

--- a/src/Factory/UriFactory.php
+++ b/src/Factory/UriFactory.php
@@ -36,12 +36,12 @@ class UriFactory implements UriFactoryInterface
 		return new Uri(
 			!empty($uriPart["scheme"]) ? \strtolower($uriPart["scheme"]) : "http",
 			!empty($uriPart["host"]) ? \strtolower($uriPart["host"]) : "",
-			$uriPart["path"] ?? "",
+			$uriPart["path"] ?? null,
 			!empty($uriPart["port"]) ? $uriPart["port"] : null,
-			$uriPart["user"] ?? "",
-			$uriPart["pass"] ?? "",
-			$uriPart["query"] ?? "",
-			$uriPart["fragment"] ?? ""
+			$uriPart["user"] ?? null,
+			$uriPart["pass"] ?? null,
+			$uriPart["query"] ?? null,
+			$uriPart["fragment"] ?? null
 		);
 	}
 }

--- a/src/Factory/UriFactory.php
+++ b/src/Factory/UriFactory.php
@@ -26,7 +26,6 @@ class UriFactory implements UriFactoryInterface
 	 */
 	public static function createFromString(string $uri): Uri
 	{
-		// Parse the URI
 		$uriPart = \parse_url($uri);
 
 		if( $uriPart === false ){
@@ -34,8 +33,8 @@ class UriFactory implements UriFactoryInterface
 		}
 
 		return new Uri(
-			!empty($uriPart["scheme"]) ? \strtolower($uriPart["scheme"]) : "http",
-			!empty($uriPart["host"]) ? \strtolower($uriPart["host"]) : "",
+			!empty($uriPart["scheme"]) ? \strtolower($uriPart["scheme"]) : null,
+			!empty($uriPart["host"]) ? \strtolower($uriPart["host"]) : null,
 			$uriPart["path"] ?? null,
 			!empty($uriPart["port"]) ? $uriPart["port"] : null,
 			$uriPart["user"] ?? null,

--- a/src/Factory/UriFactory.php
+++ b/src/Factory/UriFactory.php
@@ -24,7 +24,7 @@ class UriFactory implements UriFactoryInterface
 	 * @throws RuntimeException
 	 * @return Uri
 	 */
-	public static function createFromString(string $uri): UriInterface
+	public static function createFromString(string $uri): Uri
 	{
 		// Parse the URI
 		$uriPart = \parse_url($uri);

--- a/src/MessageAbstract.php
+++ b/src/MessageAbstract.php
@@ -134,7 +134,7 @@ abstract class MessageAbstract implements MessageInterface
 	 * @param string|array<string> $value
 	 * @return static
 	 */
-	public function withHeader($name, $value): self
+	public function withHeader($name, $value): static
 	{
 		$instance = clone $this;
 
@@ -158,7 +158,7 @@ abstract class MessageAbstract implements MessageInterface
 	 * @param string|array<string> $value
 	 * @return static
 	 */
-	public function withAddedHeader($name, $value): self
+	public function withAddedHeader($name, $value): static
 	{
 		$key = $this->findHeaderKey($name);
 
@@ -185,7 +185,7 @@ abstract class MessageAbstract implements MessageInterface
 	 * @param string $name
 	 * @return static
 	 */
-	public function withoutHeader($name): self
+	public function withoutHeader($name): static
 	{
 		$key = $this->findHeaderKey($name);
 
@@ -252,7 +252,7 @@ abstract class MessageAbstract implements MessageInterface
 	 * @inheritDoc
 	 * @return static
 	 */
-	public function withBody(StreamInterface $body): self
+	public function withBody(StreamInterface $body): static
 	{
 		$instance = clone $this;
 		$instance->body = $body;

--- a/src/MessageAbstract.php
+++ b/src/MessageAbstract.php
@@ -106,11 +106,11 @@ abstract class MessageAbstract implements MessageInterface
 	{
 		$key = $this->findHeaderKey($name);
 
-		if( $key !== null ){
-			return $this->headers[$key];
+		if( $key === null ){
+			return [];
 		}
 
-		return [];
+		return $this->headers[$key];
 	}
 
 	/**
@@ -138,7 +138,9 @@ abstract class MessageAbstract implements MessageInterface
 	{
 		$instance = clone $this;
 
-		if( ($key = $this->findHeaderKey($name)) === null ){
+		$key = $this->findHeaderKey($name);
+
+		if( $key === null ){
 			$key = $name;
 		}
 
@@ -158,7 +160,9 @@ abstract class MessageAbstract implements MessageInterface
 	 */
 	public function withAddedHeader($name, $value): self
 	{
-		if( ($key = $this->findHeaderKey($name)) === null ){
+		$key = $this->findHeaderKey($name);
+
+		if( $key === null ){
 			$key = $name;
 		}
 
@@ -183,7 +187,9 @@ abstract class MessageAbstract implements MessageInterface
 	 */
 	public function withoutHeader($name): self
 	{
-		if( ($key = $this->findHeaderKey($name)) === null ){
+		$key = $this->findHeaderKey($name);
+
+		if( $key === null ){
 			return $this;
 		}
 

--- a/src/MessageAbstract.php
+++ b/src/MessageAbstract.php
@@ -35,7 +35,7 @@ abstract class MessageAbstract implements MessageInterface
 	 * @var array<string>
 	 */
 	private array $allowedVersions = [
-		"1.1", "1.0", "2", "2.0"
+		"1", "1.0", "1.1", "2", "2.0"
 	];
 
 	/**

--- a/src/MessageAbstract.php
+++ b/src/MessageAbstract.php
@@ -1,11 +1,10 @@
-<?php declare(strict_types=1);
+<?php
 
-namespace Capsule;
+namespace Nimbly\Capsule;
 
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
-
 
 abstract class MessageAbstract implements MessageInterface
 {
@@ -14,28 +13,28 @@ abstract class MessageAbstract implements MessageInterface
 	 *
 	 * @var string
 	 */
-	protected $version = "1.1";
+	protected string $version = "1.1";
 
 	/**
 	 * Message headers
 	 *
 	 * @var array<string,array<string>>
 	 */
-	protected $headers = [];
+	protected array $headers = [];
 
 	/**
 	 * Message body
 	 *
 	 * @var StreamInterface
 	 */
-	protected $body;
+	protected StreamInterface $body;
 
 	/**
 	 * Allowed HTTP versions
 	 *
 	 * @var array<string>
 	 */
-	private $allowedVersions = [
+	private array $allowedVersions = [
 		"1.1", "1.0", "2", "2.0"
 	];
 
@@ -105,7 +104,9 @@ abstract class MessageAbstract implements MessageInterface
 	 */
 	public function getHeader($name): array
 	{
-		if( ($key = $this->findHeaderKey($name)) !== null ){
+		$key = $this->findHeaderKey($name);
+
+		if( $key !== null ){
 			return $this->headers[$key];
 		}
 
@@ -219,7 +220,7 @@ abstract class MessageAbstract implements MessageInterface
 	 */
 	protected function setHostHeader(string $host, ?int $port = null): void
 	{
-		if( ($key = $this->findHeaderKey('Host')) ){
+		if( ($key = $this->findHeaderKey("Host")) ){
 			unset($this->headers[$key]);
 		}
 
@@ -228,7 +229,7 @@ abstract class MessageAbstract implements MessageInterface
 		}
 
 		$this->headers = \array_merge(
-			['Host' => [$host]],
+			["Host" => [$host]],
 			$this->headers
 		);
 	}
@@ -236,7 +237,7 @@ abstract class MessageAbstract implements MessageInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function getBody(): ?StreamInterface
+	public function getBody(): StreamInterface
 	{
 		return $this->body;
 	}

--- a/src/Request.php
+++ b/src/Request.php
@@ -1,50 +1,53 @@
-<?php declare(strict_types=1);
+<?php
 
-namespace Capsule;
+namespace Nimbly\Capsule;
 
-use Capsule\Factory\UriFactory;
-use Capsule\Stream\BufferStream;
+use Nimbly\Capsule\Factory\StreamFactory;
+use Nimbly\Capsule\Factory\UriFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
-
 class Request extends MessageAbstract implements RequestInterface
 {
-    /**
-     * HTTP method
-     *
-     * @var string
-     */
-    protected $method;
+	/**
+	 * HTTP method
+	 *
+	 * @var string
+	 */
+	protected string $method;
 
-    /**
-     * Request URI
-     *
-     * @var UriInterface
-     */
-    protected $uri;
+	/**
+	 * Request URI
+	 *
+	 * @var UriInterface
+	 */
+	protected UriInterface $uri;
 
-    /**
-     * Request target form
-     *
-     * @var string
-	 * @psalm-suppress PropertyNotSetInConstructor
-     */
-    protected $requestTarget;
+	/**
+	 * Request target form
+	 *
+	 * @var string|null
+	 */
+	protected ?string $requestTarget = null;
 
-    /**
-     * @param string $method
-     * @param UriInterface|string $uri
-     * @param StreamInterface|string|null $body
-     * @param array<string,string> $headers
-     * @param string $httpVersion
-     */
-    public function __construct(string $method, $uri, $body = null, array $headers = [], string $httpVersion = "1.1")
-    {
-        $this->method = \strtoupper($method);
-        $this->uri = $uri instanceof UriInterface ? $uri : UriFactory::createFromString($uri);
-        $this->body = $body instanceof StreamInterface ? $body : new BufferStream((string) $body);
+	/**
+	 * @param string $method
+	 * @param string|UriInterface|string $uri
+	 * @param string|StreamInterface|null $body
+	 * @param array<string,string> $headers
+	 * @param string $httpVersion
+	 */
+	public function __construct(
+		string $method,
+		UriInterface|string $uri,
+		StreamInterface|string|null $body = null,
+		array $headers = [],
+		string $httpVersion = "1.1")
+	{
+		$this->method = \strtoupper($method);
+		$this->uri = $uri instanceof UriInterface ? $uri : UriFactory::createFromString($uri);
+		$this->body = $body instanceof StreamInterface ? $body : StreamFactory::createFromString((string) $body);
 
 		$this->setHeaders($headers);
 
@@ -52,61 +55,61 @@ class Request extends MessageAbstract implements RequestInterface
 			$this->setHostHeader($this->uri->getHost(), $this->uri->getPort());
 		}
 
-        $this->version = $httpVersion;
+		$this->version = $httpVersion;
 	}
 
-    /**
-     * @inheritDoc
+	/**
+	 * @inheritDoc
 	 * @param string $method
 	 * @return static
-     */
-    public function withMethod($method): Request
-    {
-        $instance = clone $this;
-        $instance->method = \strtoupper($method);
-        return $instance;
-    }
+	 */
+	public function withMethod($method): Request
+	{
+		$instance = clone $this;
+		$instance->method = \strtoupper($method);
+		return $instance;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function getMethod(): string
-    {
-        return $this->method;
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function getMethod(): string
+	{
+		return $this->method;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function getUri(): UriInterface
-    {
-        return $this->uri;
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function getUri(): UriInterface
+	{
+		return $this->uri;
+	}
 
-    /**
-     * @inheritDoc
+	/**
+	 * @inheritDoc
 	 * @param UriInterface $uri
 	 * @param bool $preserveHost
 	 * @return static
-     */
-    public function withUri(UriInterface $uri, $preserveHost = false): Request
-    {
-        $instance = clone $this;
+	 */
+	public function withUri(UriInterface $uri, $preserveHost = false): Request
+	{
+		$instance = clone $this;
 		$instance->uri = $uri;
 
 		if( $preserveHost === false ||
-			$this->hasHeader('Host') === false ){
+			$this->hasHeader("Host") === false ){
 			$instance->setHostHeader($uri->getHost(), $uri->getPort());
 		}
 
-        return $instance;
-    }
+		return $instance;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function getRequestTarget(): string
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function getRequestTarget(): string
+	{
 		if( !empty($this->requestTarget) ){
 			return $this->requestTarget;
 		}
@@ -121,18 +124,18 @@ class Request extends MessageAbstract implements RequestInterface
 			$requestTarget .= "?" . $this->uri->getQuery();
 		}
 
-        return $requestTarget;
-    }
+		return $requestTarget;
+	}
 
-    /**
-     * @inheritDoc
+	/**
+	 * @inheritDoc
 	 * @param mixed $requestTarget
 	 * @return static
-     */
-    public function withRequestTarget($requestTarget): Request
-    {
-        $instance = clone $this;
-        $instance->requestTarget = $requestTarget;
-        return $instance;
-    }
+	 */
+	public function withRequestTarget($requestTarget): Request
+	{
+		$instance = clone $this;
+		$instance->requestTarget = $requestTarget;
+		return $instance;
+	}
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -33,15 +33,15 @@ class Request extends MessageAbstract implements RequestInterface
 
 	/**
 	 * @param string $method
-	 * @param string|UriInterface|string $uri
+	 * @param string|UriInterface $uri
 	 * @param string|StreamInterface|null $body
 	 * @param array<string,string> $headers
 	 * @param string $httpVersion
 	 */
 	public function __construct(
 		string $method,
-		UriInterface|string $uri,
-		StreamInterface|string|null $body = null,
+		string|UriInterface $uri,
+		string|StreamInterface|null $body = null,
 		array $headers = [],
 		string $httpVersion = "1.1")
 	{

--- a/src/Request.php
+++ b/src/Request.php
@@ -63,7 +63,7 @@ class Request extends MessageAbstract implements RequestInterface
 	 * @param string $method
 	 * @return static
 	 */
-	public function withMethod($method): Request
+	public function withMethod($method): static
 	{
 		$instance = clone $this;
 		$instance->method = \strtoupper($method);
@@ -92,7 +92,7 @@ class Request extends MessageAbstract implements RequestInterface
 	 * @param bool $preserveHost
 	 * @return static
 	 */
-	public function withUri(UriInterface $uri, $preserveHost = false): Request
+	public function withUri(UriInterface $uri, $preserveHost = false): static
 	{
 		$instance = clone $this;
 		$instance->uri = $uri;
@@ -132,7 +132,7 @@ class Request extends MessageAbstract implements RequestInterface
 	 * @param mixed $requestTarget
 	 * @return static
 	 */
-	public function withRequestTarget($requestTarget): Request
+	public function withRequestTarget($requestTarget): static
 	{
 		$instance = clone $this;
 		$instance->requestTarget = $requestTarget;

--- a/src/Response.php
+++ b/src/Response.php
@@ -2,9 +2,9 @@
 
 namespace Nimbly\Capsule;
 
+use Nimbly\Capsule\Factory\StreamFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
-use Nimbly\Capsule\Stream\BufferStream;
 
 class Response extends MessageAbstract implements ResponseInterface
 {
@@ -26,7 +26,7 @@ class Response extends MessageAbstract implements ResponseInterface
 		string $httpVersion = "1.1")
 	{
 		$this->statusCode = $statusCode;
-		$this->body = $body instanceof StreamInterface ? $body : new BufferStream((string) $body);
+		$this->body = $body instanceof StreamInterface ? $body : StreamFactory::createFromString((string) $body);
 		$this->reasonPhrase = $reasonPhrase ?: ResponseStatus::getPhrase($statusCode);
 		$this->setHeaders($headers);
 		$this->version = $httpVersion;

--- a/src/Response.php
+++ b/src/Response.php
@@ -46,7 +46,7 @@ class Response extends MessageAbstract implements ResponseInterface
 	 * @param string $reasonPhrase
 	 * @return static
 	 */
-	public function withStatus($code, $reasonPhrase = ""): Response
+	public function withStatus($code, $reasonPhrase = ""): static
 	{
 		$instance = clone $this;
 		$instance->statusCode = $code;

--- a/src/Response.php
+++ b/src/Response.php
@@ -5,7 +5,6 @@ namespace Nimbly\Capsule;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Nimbly\Capsule\Stream\BufferStream;
-use UnexpectedValueException;
 
 class Response extends MessageAbstract implements ResponseInterface
 {
@@ -15,26 +14,22 @@ class Response extends MessageAbstract implements ResponseInterface
 	/**
 	 * Response constructor.
 	 *
-	 * @param int|ResponseStatus $statusCode
+	 * @param int $statusCode
 	 * @param string|StreamInterface $body
 	 * @param array<string,string> $headers
 	 * @param string|null $reasonPhrase
-	 * @param string $httpVersion
+	 * @param string $http_version
 	 */
 	public function __construct(
-		int|ResponseStatus $statusCode,
+		int $statusCode,
 		string|StreamInterface $body = null,
 		array $headers = [],
 		?string $reasonPhrase = null,
 		string $httpVersion = "1.1")
 	{
-		if( \is_int($statusCode) ){
-			$statusCode = ResponseStatus::from($statusCode);
-		}
-
-		$this->statusCode = $statusCode->value;
+		$this->statusCode = $statusCode;
 		$this->body = $body instanceof StreamInterface ? $body : new BufferStream((string) $body);
-		$this->reasonPhrase = $reasonPhrase ?: $statusCode->getPhrase();
+		$this->reasonPhrase = $reasonPhrase ?: ResponseStatus::getPhrase($statusCode);
 		$this->setHeaders($headers);
 		$this->version = $httpVersion;
 	}
@@ -49,22 +44,15 @@ class Response extends MessageAbstract implements ResponseInterface
 
 	/**
 	 * @inheritDoc
-	 * @param int|ResponseStatus $code
+	 * @param int $code
 	 * @param string $reasonPhrase
 	 * @return static
 	 */
 	public function withStatus($code, $reasonPhrase = ""): Response
 	{
-		if( \is_int($code) ){
-			$code = ResponseStatus::from($code);
-		}
-		elseif( $code instanceof ResponseStatus === false ){
-			throw new UnexpectedValueException("Expecting either an integer or a ResponseStatus enum.");
-		}
-
 		$instance = clone $this;
-		$instance->statusCode = $code->value;
-		$instance->reasonPhrase = $reasonPhrase ? $reasonPhrase : $code->getPhrase();
+		$instance->statusCode = $code;
+		$instance->reasonPhrase = $reasonPhrase ?: ResponseStatus::getPhrase($code);
 		return $instance;
 	}
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -12,8 +12,6 @@ class Response extends MessageAbstract implements ResponseInterface
 	protected string $reasonPhrase;
 
 	/**
-	 * Response constructor.
-	 *
 	 * @param int $statusCode
 	 * @param string|StreamInterface $body
 	 * @param array<string,string> $headers

--- a/src/ResponseStatus.php
+++ b/src/ResponseStatus.php
@@ -2,151 +2,159 @@
 
 namespace Nimbly\Capsule;
 
-enum ResponseStatus: int
+class ResponseStatus
 {
-	case CONTINUE = 100;
-	case SWITCHING_PROTOCOLS = 101;
-	case PROCESSING = 102;
-	case EARLY_HINTS = 103;
+	const CONTINUE = 100;
+	const SWITCHING_PROTOCOLS = 101;
+	const PROCESSING = 102;
+	const EARLY_HINTS = 103;
 
-	case OK = 200;
-	case CREATED = 201;
-	case ACCEPTED = 202;
-	case NON_AUTHORITATIVE_INFORMATION = 203;
-	case NO_CONTENT = 204;
-	case RESET_CONTENT = 205;
-	case PARTIAL_CONTENT = 206;
-	case MULTI_STATUS = 207;
-	case ALREADY_REPORTED = 208;
-	case IM_USED = 226;
+	const OK = 200;
+	const CREATED = 201;
+	const ACCEPTED = 202;
+	const NON_AUTHORITATIVE_INFORMATION = 203;
+	const NO_CONTENT = 204;
+	const RESET_CONTENT = 205;
+	const PARTIAL_CONTENT = 206;
+	const MULTI_STATUS = 207;
+	const ALREADY_REPORTED = 208;
+	const IM_USED = 226;
 
-	case MULTIPLE_CHOICES = 300;
-	case MOVED_PERMENENTLY = 301;
-	case FOUND = 302;
-	case SEE_OTHER = 303;
-	case NOT_MODIFIED = 304;
-	case USE_PROXY = 305;
-	case SWITCH_PROXY = 306;
-	case TEMPORARY_REDIRECT = 307;
-	case PERMANENT_REDIRECT = 308;
+	const MULTIPLE_CHOICES = 300;
+	const MOVED_PERMENENTLY = 301;
+	const FOUND = 302;
+	const SEE_OTHER = 303;
+	const NOT_MODIFIED = 304;
+	const USE_PROXY = 305;
+	const SWITCH_PROXY = 306;
+	const TEMPORARY_REDIRECT = 307;
+	const PERMANENT_REDIRECT = 308;
 
-	case BAD_REQUEST = 400;
-	case UNAUTHORIZED = 401;
-	case PAYMENT_REQUIRED = 402;
-	case FORBIDDEN = 403;
-	case NOT_FOUND = 404;
-	case METHOD_NOT_ALLOWED = 405;
-	case NOT_ACCEPTABLE = 406;
-	case PROXY_AUTHENTICATION_REQUIRED = 407;
-	case REQUEST_TIMEOUT = 408;
-	case CONFLICT = 409;
-	case GONE = 410;
-	case LENGTH_REQUIRED = 411;
-	case PRECONDITION_FAILED = 412;
-	case PAYLOAD_TOO_LARGE = 413;
-	case URI_TOO_LONG = 414;
-	case UNSUPPORTED_MEDIA_TYPE = 415;
-	case RANGE_NOT_SATISFIABLE = 416;
-	case EXPECTATION_FAILED = 417;
-	case IM_A_TEAPOT = 418;
-	case MISDIRECTED_REQUEST = 421;
-	case UNPROCESSABLE_ENTITY = 422;
-	case LOCKED = 423;
-	case FAILED_DEPENDENCY = 424;
-	case TOO_EARLY = 425;
-	case UPGRADE_REQUIRED = 426;
-	case PRECONDITION_REQUIRED = 428;
-	case TOO_MANY_REQUESTS = 429;
-	case REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
-	case UNAVAILBLE_FOR_LEGAL_REASONS = 451;
+	const BAD_REQUEST = 400;
+	const UNAUTHORIZED = 401;
+	const PAYMENT_REQUIRED = 402;
+	const FORBIDDEN = 403;
+	const NOT_FOUND = 404;
+	const METHOD_NOT_ALLOWED = 405;
+	const NOT_ACCEPTABLE = 406;
+	const PROXY_AUTHENTICATION_REQUIRED = 407;
+	const REQUEST_TIMEOUT = 408;
+	const CONFLICT = 409;
+	const GONE = 410;
+	const LENGTH_REQUIRED = 411;
+	const PRECONDITION_FAILED = 412;
+	const PAYLOAD_TOO_LARGE = 413;
+	const URI_TOO_LONG = 414;
+	const UNSUPPORTED_MEDIA_TYPE = 415;
+	const RANGE_NOT_SATISFIABLE = 416;
+	const EXPECTATION_FAILED = 417;
+	const IM_A_TEAPOT = 418;
+	const MISDIRECTED_REQUEST = 421;
+	const UNPROCESSABLE_ENTITY = 422;
+	const LOCKED = 423;
+	const FAILED_DEPENDENCY = 424;
+	const TOO_EARLY = 425;
+	const UPGRADE_REQUIRED = 426;
+	const PRECONDITION_REQUIRED = 428;
+	const TOO_MANY_REQUESTS = 429;
+	const REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
+	const UNAVAILBLE_FOR_LEGAL_REASONS = 451;
 
-	case INTERNAL_SERVER_ERROR = 500;
-	case NOT_IMPLEMENTED = 501;
-	case BAD_GATEWAY = 502;
-	case SERVICE_UNAVAILABLE = 503;
-	case GATEWAY_TIMEOUT = 504;
-	case HTTP_VERSION_NOT_SUPPORTED = 505;
-	case VARIANT_ALSO_NEGOTIATES = 506;
-	case INSUFFICIENT_STORAGE = 507;
-	case LOOP_DETECTED = 508;
-	case NOT_EXTENDED = 510;
-	case NETWORK_AUTHENTICATION_REQUIRED = 511;
+	const INTERNAL_SERVER_ERROR = 500;
+	const NOT_IMPLEMENTED = 501;
+	const BAD_GATEWAY = 502;
+	const SERVICE_UNAVAILABLE = 503;
+	const GATEWAY_TIMEOUT = 504;
+	const HTTP_VERSION_NOT_SUPPORTED = 505;
+	const VARIANT_ALSO_NEGOTIATES = 506;
+	const INSUFFICIENT_STORAGE = 507;
+	const LOOP_DETECTED = 508;
+	const NOT_EXTENDED = 510;
+	const NETWORK_AUTHENTICATION_REQUIRED = 511;
+
+	/**
+	 * Official HTTP status codes mapped to their response phrase.
+	 *
+	 * @var array<int,string>
+	 */
+	protected static array $phrases = [
+		self::CONTINUE => "Continue",
+		self::SWITCHING_PROTOCOLS => "Switching Protocols",
+		self::PROCESSING => "Processing",
+		self::EARLY_HINTS => "Early Hints",
+
+		self::OK => "Ok",
+		self::CREATED => "Created",
+		self::ACCEPTED => "Accepted",
+		self::NON_AUTHORITATIVE_INFORMATION => "Non-Authoritative Information",
+		self::NO_CONTENT => "No Content",
+		self::RESET_CONTENT => "Reset Content",
+		self::PARTIAL_CONTENT => "Partial Content",
+		self::MULTI_STATUS => "Multi-Status",
+		self::ALREADY_REPORTED => "Already Reported",
+		self::IM_USED => "IM Used",
+
+		self::MULTIPLE_CHOICES => "Multiple Choices",
+		self::MOVED_PERMENENTLY => "Moved Permanently",
+		self::FOUND => "Found",
+		self::SEE_OTHER => "See Other",
+		self::NOT_MODIFIED => "Not Modified",
+		self::USE_PROXY => "Use Proxy",
+		self::SWITCH_PROXY => "Switch Proxy",
+		self::TEMPORARY_REDIRECT => "Temporary Redirect",
+		self::PERMANENT_REDIRECT => "Permanent Redirect",
+
+		self::BAD_REQUEST => "Bad Request",
+		self::UNAUTHORIZED => "Unauthorized",
+		self::PAYMENT_REQUIRED => "Payment Required",
+		self::FORBIDDEN => "Forbidden",
+		self::NOT_FOUND => "Not Found",
+		self::METHOD_NOT_ALLOWED => "Method Not Allowed",
+		self::NOT_ACCEPTABLE => "Not Acceptable",
+		self::PROXY_AUTHENTICATION_REQUIRED => "Proxy Authentication Required",
+		self::REQUEST_TIMEOUT => "Request Timeout",
+		self::CONFLICT => "Conflict",
+		self::GONE => "Gone",
+		self::LENGTH_REQUIRED => "Length Required",
+		self::PRECONDITION_FAILED => "Precondition Failed",
+		self::PAYLOAD_TOO_LARGE => "Payload Too Large",
+		self::URI_TOO_LONG => "URI Too Long",
+		self::UNSUPPORTED_MEDIA_TYPE => "Unsupported Media Type",
+		self::RANGE_NOT_SATISFIABLE => "Range Not Satisfiable",
+		self::EXPECTATION_FAILED => "Expection Failed",
+		self::IM_A_TEAPOT => "I'm A Teapot",
+		self::MISDIRECTED_REQUEST => "Misdirected Request",
+		self::UNPROCESSABLE_ENTITY => "Unprocessable Entity",
+		self::LOCKED => "Locked",
+		self::FAILED_DEPENDENCY => "Failed Dependency",
+		self::TOO_EARLY => "Too Early",
+		self::UPGRADE_REQUIRED => "Upgrade Required",
+		self::PRECONDITION_REQUIRED => "Precondition Required",
+		self::TOO_MANY_REQUESTS => "Too Many Requests",
+		self::REQUEST_HEADER_FIELDS_TOO_LARGE => "Request Header Fields Too Large",
+		self::UNAVAILBLE_FOR_LEGAL_REASONS => "Unavailable For Legal Reasons",
+
+		self::INTERNAL_SERVER_ERROR => "Internal Server Error",
+		self::NOT_IMPLEMENTED => "Not Implemented",
+		self::BAD_GATEWAY => "Bad Gateway",
+		self::SERVICE_UNAVAILABLE => "Service Unavailable",
+		self::GATEWAY_TIMEOUT => "Gateway Timeout",
+		self::HTTP_VERSION_NOT_SUPPORTED => "HTTP Version Not Supported",
+		self::VARIANT_ALSO_NEGOTIATES => "Variant Also Negotiates",
+		self::INSUFFICIENT_STORAGE => "Insufficient Storage",
+		self::LOOP_DETECTED => "Loop Detected",
+		self::NOT_EXTENDED => "Not Extended",
+		self::NETWORK_AUTHENTICATION_REQUIRED => "Network Authentication Required"
+	];
 
 	/**
 	 * Get the HTTP phrase for the response.
 	 *
+	 * @param int $status_code The HTTP status code to get the default reason phrase for.
 	 * @return string
 	 */
-	public function getPhrase(): string
+	public static function getPhrase(int $status_code): string
 	{
-		return match($this) {
-			self::CONTINUE => "Continue",
-			self::SWITCHING_PROTOCOLS => "Switching Protocols",
-			self::PROCESSING => "Processing",
-			self::EARLY_HINTS => "Early Hints",
-
-			self::OK => "Ok",
-			self::CREATED => "Created",
-			self::ACCEPTED => "Accepted",
-			self::NON_AUTHORITATIVE_INFORMATION => "Non-Authoritative Information",
-			self::NO_CONTENT => "No Content",
-			self::RESET_CONTENT => "Reset Content",
-			self::PARTIAL_CONTENT => "Partial Content",
-			self::MULTI_STATUS => "Multi-Status",
-			self::ALREADY_REPORTED => "Already Reported",
-			self::IM_USED => "IM Used",
-
-			self::MULTIPLE_CHOICES => "Multiple Choices",
-			self::MOVED_PERMENENTLY => "Moved Permanently",
-			self::FOUND => "Found",
-			self::SEE_OTHER => "See Other",
-			self::NOT_MODIFIED => "Not Modified",
-			self::USE_PROXY => "Use Proxy",
-			self::SWITCH_PROXY => "Switch Proxy",
-			self::TEMPORARY_REDIRECT => "Temporary Redirect",
-			self::PERMANENT_REDIRECT => "Permanent Redirect",
-
-			self::BAD_REQUEST => "Bad Request",
-			self::UNAUTHORIZED => "Unauthorized",
-			self::PAYMENT_REQUIRED => "Payment Required",
-			self::FORBIDDEN => "Forbidden",
-			self::NOT_FOUND => "Not Found",
-			self::METHOD_NOT_ALLOWED => "Method Not Allowed",
-			self::NOT_ACCEPTABLE => "Not Acceptable",
-			self::PROXY_AUTHENTICATION_REQUIRED => "Proxy Authentication Required",
-			self::REQUEST_TIMEOUT => "Request Timeout",
-			self::CONFLICT => "Conflict",
-			self::GONE => "Gone",
-			self::LENGTH_REQUIRED => "Length Required",
-			self::PRECONDITION_FAILED => "Precondition Failed",
-			self::PAYLOAD_TOO_LARGE => "Payload Too Large",
-			self::URI_TOO_LONG => "URI Too Long",
-			self::UNSUPPORTED_MEDIA_TYPE => "Unsupported Media Type",
-			self::RANGE_NOT_SATISFIABLE => "Range Not Satisfiable",
-			self::EXPECTATION_FAILED => "Expection Failed",
-			self::IM_A_TEAPOT => "I'm A Teapot",
-			self::MISDIRECTED_REQUEST => "Misdirected Request",
-			self::UNPROCESSABLE_ENTITY => "Unprocessable Entity",
-			self::LOCKED => "Locked",
-			self::FAILED_DEPENDENCY => "Failed Dependency",
-			self::TOO_EARLY => "Too Early",
-			self::UPGRADE_REQUIRED => "Upgrade Required",
-			self::PRECONDITION_REQUIRED => "Precondition Required",
-			self::TOO_MANY_REQUESTS => "Too Many Requests",
-			self::REQUEST_HEADER_FIELDS_TOO_LARGE => "Request Header Fields Too Large",
-			self::UNAVAILBLE_FOR_LEGAL_REASONS => "Unavailable For Legal Reasons",
-
-			self::INTERNAL_SERVER_ERROR => "Internal Server Error",
-			self::NOT_IMPLEMENTED => "Not Implemented",
-			self::BAD_GATEWAY => "Bad Gateway",
-			self::SERVICE_UNAVAILABLE => "Service Unavailable",
-			self::GATEWAY_TIMEOUT => "Gateway Timeout",
-			self::HTTP_VERSION_NOT_SUPPORTED => "HTTP Version Not Supported",
-			self::VARIANT_ALSO_NEGOTIATES => "Variant Also Negotiates",
-			self::INSUFFICIENT_STORAGE => "Insufficient Storage",
-			self::LOOP_DETECTED => "Loop Detected",
-			self::NOT_EXTENDED => "Not Extended",
-			self::NETWORK_AUTHENTICATION_REQUIRED => "Network Authentication Required"
-		};
+		return self::$phrases[$status_code] ?? "";
 	}
 }

--- a/src/ResponseStatus.php
+++ b/src/ResponseStatus.php
@@ -1,158 +1,152 @@
-<?php declare(strict_types=1);
+<?php
 
-namespace Capsule;
+namespace Nimbly\Capsule;
 
-
-class ResponseStatus
+enum ResponseStatus: int
 {
-	const CONTINUE = 100;
-	const SWITCHING_PROTOCOLS = 101;
-	const PROCESSING = 102;
-	const EARLY_HINTS = 103;
+	case CONTINUE = 100;
+	case SWITCHING_PROTOCOLS = 101;
+	case PROCESSING = 102;
+	case EARLY_HINTS = 103;
 
-	const OK = 200;
-	const CREATED = 201;
-	const ACCEPTED = 202;
-	const NON_AUTHORITATIVE_INFORMATION = 203;
-	const NO_CONTENT = 204;
-	const RESET_CONTENT = 205;
-	const PARTIAL_CONTENT = 206;
-	const MULTI_STATUS = 207;
-	const ALREADY_REPORTED = 208;
-	const IM_USED = 226;
+	case OK = 200;
+	case CREATED = 201;
+	case ACCEPTED = 202;
+	case NON_AUTHORITATIVE_INFORMATION = 203;
+	case NO_CONTENT = 204;
+	case RESET_CONTENT = 205;
+	case PARTIAL_CONTENT = 206;
+	case MULTI_STATUS = 207;
+	case ALREADY_REPORTED = 208;
+	case IM_USED = 226;
 
-	const MULTIPLE_CHOICES = 300;
-	const MOVED_PERMENENTLY = 301;
-	const FOUND = 302;
-	const SEE_OTHER = 303;
-	const NOT_MODIFIED = 304;
-	const USE_PROXY = 305;
-	const SWITCH_PROXY = 306;
-	const TEMPORARY_REDIRECTS = 307;
-	const PERMANENT_REDIRECTS = 308;
+	case MULTIPLE_CHOICES = 300;
+	case MOVED_PERMENENTLY = 301;
+	case FOUND = 302;
+	case SEE_OTHER = 303;
+	case NOT_MODIFIED = 304;
+	case USE_PROXY = 305;
+	case SWITCH_PROXY = 306;
+	case TEMPORARY_REDIRECT = 307;
+	case PERMANENT_REDIRECT = 308;
 
-	const BAD_REQUEST = 400;
-	const UNAUTHORIZED = 401;
-	const PAYMENT_REQUIRED = 402;
-	const FORBIDDEN = 403;
-	const NOT_FOUND = 404;
-	const METHOD_NOT_ALLOWED = 405;
-	const NOT_ACCEPTABLE = 406;
-	const PROXY_AUTHENTICATION_REQUIRED = 407;
-	const REQUEST_TIMEOUT = 408;
-	const CONFLICT = 409;
-	const GONE = 410;
-	const LENGTH_REQUIRED = 411;
-	const PRECONDITION_FAILED = 412;
-	const PAYLOAD_TOO_LARGE = 413;
-	const URI_TOO_LONG = 414;
-	const UNSUPPORTED_MEDIA_TYPE = 415;
-	const RANGE_NOT_SATISFIABLE = 416;
-	const EXPECTATION_FAILED = 417;
-	const IM_A_TEAPOT = 418;
-	const MISDIRECTED_REQUEST = 421;
-	const UNPROCESSABLE_ENTITY = 422;
-	const LOCKED = 423;
-	const FAILED_DEPENDENCY = 424;
-	const UPGRADE_REQUIRED = 426;
-	const PRECONDITION_REQUIRED = 428;
-	const TOO_MANY_REQUESTS = 429;
-	const REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
-	const UNAVAILBLE_FOR_LEGAL_REASONS = 451;
+	case BAD_REQUEST = 400;
+	case UNAUTHORIZED = 401;
+	case PAYMENT_REQUIRED = 402;
+	case FORBIDDEN = 403;
+	case NOT_FOUND = 404;
+	case METHOD_NOT_ALLOWED = 405;
+	case NOT_ACCEPTABLE = 406;
+	case PROXY_AUTHENTICATION_REQUIRED = 407;
+	case REQUEST_TIMEOUT = 408;
+	case CONFLICT = 409;
+	case GONE = 410;
+	case LENGTH_REQUIRED = 411;
+	case PRECONDITION_FAILED = 412;
+	case PAYLOAD_TOO_LARGE = 413;
+	case URI_TOO_LONG = 414;
+	case UNSUPPORTED_MEDIA_TYPE = 415;
+	case RANGE_NOT_SATISFIABLE = 416;
+	case EXPECTATION_FAILED = 417;
+	case IM_A_TEAPOT = 418;
+	case MISDIRECTED_REQUEST = 421;
+	case UNPROCESSABLE_ENTITY = 422;
+	case LOCKED = 423;
+	case FAILED_DEPENDENCY = 424;
+	case TOO_EARLY = 425;
+	case UPGRADE_REQUIRED = 426;
+	case PRECONDITION_REQUIRED = 428;
+	case TOO_MANY_REQUESTS = 429;
+	case REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
+	case UNAVAILBLE_FOR_LEGAL_REASONS = 451;
 
-	const INTERNAL_SERVER_ERROR = 500;
-	const NOT_IMPLEMENTED = 501;
-	const BAD_GATEWAY = 502;
-	const SERVICE_UNAVAILABLE = 503;
-	const HTTP_VERSION_NOT_SUPPORTED = 505;
-	const VARIANT_ALSO_NEGOTIATES = 506;
-	const INSUFFICIENT_STORAGE = 507;
-	const LOOP_DETECTED = 508;
-	const NOT_EXTENDED = 510;
-	const NETWORK_AUTHENTICATION_REQUIRED = 511;
+	case INTERNAL_SERVER_ERROR = 500;
+	case NOT_IMPLEMENTED = 501;
+	case BAD_GATEWAY = 502;
+	case SERVICE_UNAVAILABLE = 503;
+	case GATEWAY_TIMEOUT = 504;
+	case HTTP_VERSION_NOT_SUPPORTED = 505;
+	case VARIANT_ALSO_NEGOTIATES = 506;
+	case INSUFFICIENT_STORAGE = 507;
+	case LOOP_DETECTED = 508;
+	case NOT_EXTENDED = 510;
+	case NETWORK_AUTHENTICATION_REQUIRED = 511;
 
-    /**
-     * Official HTTP status codes mapped to their response phrase.
-     *
-     * @var array
-     */
-    protected static $phrases = [
-        100 => "Continue",
-        101 => "Switching Protocols",
-        102 => "Processing",
-        103 => "Early Hints",
+	/**
+	 * Get the HTTP phrase for the response.
+	 *
+	 * @return string
+	 */
+	public function getPhrase(): string
+	{
+		return match($this) {
+			self::CONTINUE => "Continue",
+			self::SWITCHING_PROTOCOLS => "Switching Protocols",
+			self::PROCESSING => "Processing",
+			self::EARLY_HINTS => "Early Hints",
 
-        200 => "OK",
-        201 => "Created",
-        202 => "Accepted",
-        203 => "Non-Authoritative Information",
-        204 => "No Content",
-        205 => "Reset Content",
-        206 => "Partial Content",
-        207 => "Multi-Status",
-        208 => "Already Reported",
-        226 => "IM Used",
+			self::OK => "Ok",
+			self::CREATED => "Created",
+			self::ACCEPTED => "Accepted",
+			self::NON_AUTHORITATIVE_INFORMATION => "Non-Authoritative Information",
+			self::NO_CONTENT => "No Content",
+			self::RESET_CONTENT => "Reset Content",
+			self::PARTIAL_CONTENT => "Partial Content",
+			self::MULTI_STATUS => "Multi-Status",
+			self::ALREADY_REPORTED => "Already Reported",
+			self::IM_USED => "IM Used",
 
-        300 => "Multiple Choices",
-        301 => "Moved Permanently",
-        302 => "Found",
-        303 => "See Other",
-        304 => "Not Modified",
-        305 => "Use Proxy",
-        306 => "Switch Proxy",
-        307 => "Temporary Redirect",
-        308 => "Permanent Redirect",
+			self::MULTIPLE_CHOICES => "Multiple Choices",
+			self::MOVED_PERMENENTLY => "Moved Permanently",
+			self::FOUND => "Found",
+			self::SEE_OTHER => "See Other",
+			self::NOT_MODIFIED => "Not Modified",
+			self::USE_PROXY => "Use Proxy",
+			self::SWITCH_PROXY => "Switch Proxy",
+			self::TEMPORARY_REDIRECT => "Temporary Redirect",
+			self::PERMANENT_REDIRECT => "Permanent Redirect",
 
-        400 => "Bad Request",
-        401 => "Unauthorized",
-        402 => "Payment Required",
-        403 => "Forbidden",
-        404 => "Not Found",
-        405 => "Method Not Allowed",
-        406 => "Not Acceptable",
-        407 => "Proxy Authentication Required",
-        408 => "Request Timeout",
-        409 => "Conflict",
-        410 => "Gone",
-        411 => "Length Required",
-        412 => "Precondition Failed",
-        413 => "Payload Too Large",
-        414 => "URI Too Long",
-        415 => "Unsupported Media Type",
-        416 => "Range Not Satisfiable",
-        417 => "Expection Failed",
-        418 => "I'm A Teapot",
-        421 => "Misdirected Request",
-        422 => "Unprocessable Entity",
-        423 => "Locked",
-        424 => "Failed Dependency",
-        426 => "Upgrade Required",
-        428 => "Precondition Required",
-        429 => "Too Many Requests",
-        431 => "Request Header Fields Too Large",
-        451 => "Unavailable For Legal Reasons",
+			self::BAD_REQUEST => "Bad Request",
+			self::UNAUTHORIZED => "Unauthorized",
+			self::PAYMENT_REQUIRED => "Payment Required",
+			self::FORBIDDEN => "Forbidden",
+			self::NOT_FOUND => "Not Found",
+			self::METHOD_NOT_ALLOWED => "Method Not Allowed",
+			self::NOT_ACCEPTABLE => "Not Acceptable",
+			self::PROXY_AUTHENTICATION_REQUIRED => "Proxy Authentication Required",
+			self::REQUEST_TIMEOUT => "Request Timeout",
+			self::CONFLICT => "Conflict",
+			self::GONE => "Gone",
+			self::LENGTH_REQUIRED => "Length Required",
+			self::PRECONDITION_FAILED => "Precondition Failed",
+			self::PAYLOAD_TOO_LARGE => "Payload Too Large",
+			self::URI_TOO_LONG => "URI Too Long",
+			self::UNSUPPORTED_MEDIA_TYPE => "Unsupported Media Type",
+			self::RANGE_NOT_SATISFIABLE => "Range Not Satisfiable",
+			self::EXPECTATION_FAILED => "Expection Failed",
+			self::IM_A_TEAPOT => "I'm A Teapot",
+			self::MISDIRECTED_REQUEST => "Misdirected Request",
+			self::UNPROCESSABLE_ENTITY => "Unprocessable Entity",
+			self::LOCKED => "Locked",
+			self::FAILED_DEPENDENCY => "Failed Dependency",
+			self::TOO_EARLY => "Too Early",
+			self::UPGRADE_REQUIRED => "Upgrade Required",
+			self::PRECONDITION_REQUIRED => "Precondition Required",
+			self::TOO_MANY_REQUESTS => "Too Many Requests",
+			self::REQUEST_HEADER_FIELDS_TOO_LARGE => "Request Header Fields Too Large",
+			self::UNAVAILBLE_FOR_LEGAL_REASONS => "Unavailable For Legal Reasons",
 
-        500 => "Internal Server Error",
-        501 => "Not Implemented",
-        502 => "Bad Gateway",
-        503 => "Service Unavailable",
-        504 => "Gateway Timeout",
-        505 => "HTTP Version Not Supported",
-        506 => "Variant Also Negotiates",
-        507 => "Insufficient Storage",
-        508 => "Loop Detected",
-        510 => "Not Extended",
-        511 => "Network Authentication Required",
-    ];
-
-    /**
-     * Get the response phrase based on the status code.
-     *
-     * @param int $code
-     * @return string|null
-     */
-    public static function getPhrase(int $code): ?string
-    {
-		return self::$phrases[$code] ?? null;
-    }
+			self::INTERNAL_SERVER_ERROR => "Internal Server Error",
+			self::NOT_IMPLEMENTED => "Not Implemented",
+			self::BAD_GATEWAY => "Bad Gateway",
+			self::SERVICE_UNAVAILABLE => "Service Unavailable",
+			self::GATEWAY_TIMEOUT => "Gateway Timeout",
+			self::HTTP_VERSION_NOT_SUPPORTED => "HTTP Version Not Supported",
+			self::VARIANT_ALSO_NEGOTIATES => "Variant Also Negotiates",
+			self::INSUFFICIENT_STORAGE => "Insufficient Storage",
+			self::LOOP_DETECTED => "Loop Detected",
+			self::NOT_EXTENDED => "Not Extended",
+			self::NETWORK_AUTHENTICATION_REQUIRED => "Network Authentication Required"
+		};
+	}
 }

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -104,7 +104,7 @@ class ServerRequest extends Request implements ServerRequestInterface
 	 * @inheritDoc
 	 * @return static
 	 */
-	public function withCookieParams(array $cookies): ServerRequest
+	public function withCookieParams(array $cookies): static
 	{
 		$instance = clone $this;
 		$instance->cookieParams = $cookies;
@@ -124,7 +124,7 @@ class ServerRequest extends Request implements ServerRequestInterface
 	 * @inheritDoc
 	 * @return static
 	 */
-	public function withQueryParams(array $query): ServerRequest
+	public function withQueryParams(array $query): static
 	{
 		$instance = clone $this;
 		$instance->queryParams = $query;
@@ -145,7 +145,7 @@ class ServerRequest extends Request implements ServerRequestInterface
 	 * @inheritDoc
 	 * @return static
 	 */
-	public function withUploadedFiles(array $uploadedFiles): ServerRequest
+	public function withUploadedFiles(array $uploadedFiles): static
 	{
 		$instance = clone $this;
 		$instance->uploadedFiles = $uploadedFiles;
@@ -156,7 +156,7 @@ class ServerRequest extends Request implements ServerRequestInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function getParsedBody()
+	public function getParsedBody(): mixed
 	{
 		return $this->parsedBody;
 	}
@@ -185,7 +185,7 @@ class ServerRequest extends Request implements ServerRequestInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function getAttribute($name, $default = null)
+	public function getAttribute($name, $default = null): mixed
 	{
 		return $this->attributes[$name] ?? $default;
 	}
@@ -234,10 +234,10 @@ class ServerRequest extends Request implements ServerRequestInterface
 	/**
 	 * Get a request parameter from the parsed request body.
 	 *
-	 * @param string $name
-	 * @return mixed|null
+	 * @param string $name Parsed body param name.
+	 * @return mixed|null Null is returned if body param does not exist.
 	 */
-	public function getBodyParam(string $param)
+	public function getBodyParam(string $param): mixed
 	{
 		if( \is_object($this->parsedBody) &&
 			\property_exists($this->parsedBody, $param) ){
@@ -255,7 +255,7 @@ class ServerRequest extends Request implements ServerRequestInterface
 	/**
 	 * Get only the request body parameters provided.
 	 *
-	 * @param array<string> $params
+	 * @param array<string> $params Array of body param names to return.
 	 * @return array<string,mixed>
 	 */
 	public function onlyBodyParams(array $params): array
@@ -272,7 +272,7 @@ class ServerRequest extends Request implements ServerRequestInterface
 	/**
 	 * Get all request body parameters except those provided.
 	 *
-	 * @param array<string> $params
+	 * @param array<string> $params Array of body param names to exclude.
 	 * @return array<string,mixed>
 	 */
 	public function exceptBodyParams(array $params): array

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -52,8 +52,6 @@ class ServerRequest extends Request implements ServerRequestInterface
 	protected array $serverParams = [];
 
 	/**
-	 * ServerRequest constructor.
-	 *
 	 * @param string $method
 	 * @param string|UriInterface $uri
 	 * @param string|StreamInterface $body

--- a/src/Stream/BufferStream.php
+++ b/src/Stream/BufferStream.php
@@ -174,7 +174,7 @@ class BufferStream implements StreamInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function getMetadata($key = null)
+	public function getMetadata($key = null): mixed
 	{
 		if( $key ){
 			return null;

--- a/src/Stream/BufferStream.php
+++ b/src/Stream/BufferStream.php
@@ -113,11 +113,7 @@ class BufferStream implements StreamInterface
 	 */
 	public function isWritable(): bool
 	{
-		if( $this->buffer === null ){
-			return false;
-		}
-
-		return true;
+		return $this->buffer !== null;
 	}
 
 	/**

--- a/src/Stream/BufferStream.php
+++ b/src/Stream/BufferStream.php
@@ -17,8 +17,6 @@ class BufferStream implements StreamInterface
 	protected ?string $buffer = "";
 
 	/**
-	 * BufferStream constructor.
-	 *
 	 * @param string $data
 	 */
 	public function __construct(string $data = "")

--- a/src/Stream/BufferStream.php
+++ b/src/Stream/BufferStream.php
@@ -1,191 +1,191 @@
-<?php declare(strict_types=1);
+<?php
 
-namespace Capsule\Stream;
+namespace Nimbly\Capsule\Stream;
 
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 
 class BufferStream implements StreamInterface
 {
-    /**
-     * The buffer contents.
+	/**
+	 * The buffer contents.
 	 *
 	 * When buffer is *null*, the stream has been "detached."
-     *
-     * @var string|null
-     */
-    protected $buffer = "";
+	 *
+	 * @var string|null
+	 */
+	protected ?string $buffer = "";
 
-    /**
-     * BufferStream constructor.
-     *
-     * @param string $data
-     */
-    public function __construct(string $data = "")
-    {
-        $this->buffer = $data;
-    }
+	/**
+	 * BufferStream constructor.
+	 *
+	 * @param string $data
+	 */
+	public function __construct(string $data = "")
+	{
+		$this->buffer = $data;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function __toString(): string
-    {
-        return $this->getContents();
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function __toString(): string
+	{
+		return $this->getContents();
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function close(): void
-    {
-        $this->buffer = "";
-        return;
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function close(): void
+	{
+		$this->buffer = "";
+		return;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function detach()
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function detach()
+	{
 		$this->buffer = null;
 		return null;
-    }
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function getSize(): ?int
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function getSize(): ?int
+	{
 		if( $this->buffer === null ){
 			return null;
 		}
 
-        return \strlen($this->buffer);
-    }
+		return \strlen($this->buffer);
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function tell(): int
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function tell(): int
+	{
 		if( $this->buffer === null ){
 			throw new RuntimeException("Underlying resource has been detached.");
 		}
 
-        return 0;
-    }
+		return 0;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function eof(): bool
-    {
-        return $this->buffer === null || \strlen($this->buffer) === 0;
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function eof(): bool
+	{
+		return $this->buffer === null || \strlen($this->buffer) === 0;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function isSeekable(): bool
-    {
-        return false;
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function isSeekable(): bool
+	{
+		return false;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function seek($offset, $whence = SEEK_SET): void
-    {
-        throw new RuntimeException("A BufferStream is not seekable.");
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function seek($offset, $whence = SEEK_SET): void
+	{
+		throw new RuntimeException("A BufferStream is not seekable.");
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function rewind(): void
-    {
-        $this->seek(0);
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function rewind(): void
+	{
+		$this->seek(0);
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function isWritable(): bool
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function isWritable(): bool
+	{
 		if( $this->buffer === null ){
 			return false;
 		}
 
-        return true;
-    }
+		return true;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function write($string): int
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function write($string): int
+	{
 		if( $this->buffer === null ){
 			throw new RuntimeException("Underlying resource has been detached.");
 		}
 
-        $this->buffer .= $string;
-        return \strlen($string);
-    }
+		$this->buffer .= $string;
+		return \strlen($string);
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function isReadable(): bool
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function isReadable(): bool
+	{
 		if( $this->buffer === null ){
 			return false;
 		}
 
-        return true;
-    }
+		return true;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function read($length): string
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function read($length): string
+	{
 		if( $this->buffer === null ){
 			throw new RuntimeException("Underlying resource has been detached.");
 		}
 
-        if( $length >= \strlen($this->buffer) ){
-            return $this->getContents();
-        }
+		if( $length >= \strlen($this->buffer) ){
+			return $this->getContents();
+		}
 
-        $chunk = \substr($this->buffer, 0, $length);
-        $this->buffer = \substr($this->buffer, $length);
-        return $chunk;
-    }
+		$chunk = \substr($this->buffer, 0, $length);
+		$this->buffer = \substr($this->buffer, $length);
+		return $chunk;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function getContents(): string
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function getContents(): string
+	{
 		if( $this->buffer === null ){
 			throw new RuntimeException("Underlying resource has been detached.");
 		}
 
-        $buffer = $this->buffer;
-        $this->buffer = "";
-        return $buffer;
-    }
+		$buffer = $this->buffer;
+		$this->buffer = "";
+		return $buffer;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function getMetadata($key = null)
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function getMetadata($key = null)
+	{
 		if( $key ){
 			return null;
 		}
 
-        return [];
-    }
+		return [];
+	}
 }

--- a/src/Stream/ResourceStream.php
+++ b/src/Stream/ResourceStream.php
@@ -268,7 +268,7 @@ class ResourceStream implements StreamInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function getMetadata($key = null)
+	public function getMetadata($key = null): mixed
 	{
 		if( !\is_resource($this->resource) ){
 			return $key ? null : [];

--- a/src/Stream/ResourceStream.php
+++ b/src/Stream/ResourceStream.php
@@ -110,7 +110,7 @@ class ResourceStream implements StreamInterface
 			return null;
 		}
 
-		return (int) $fstat["size"];
+		return $fstat["size"];
 	}
 
 	/**

--- a/src/Stream/ResourceStream.php
+++ b/src/Stream/ResourceStream.php
@@ -1,6 +1,6 @@
-<?php declare(strict_types=1);
+<?php
 
-namespace Capsule\Stream;
+namespace Nimbly\Capsule\Stream;
 
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
@@ -10,41 +10,41 @@ use RuntimeException;
  */
 class ResourceStream implements StreamInterface
 {
-    /**
-     * Array of file modes broken into readable and writeable.
-     *
-     * @var array<string,array<string>>
-     */
-    private $fileModes = [
-        "readable" => [
-            "r", "r+", "w+", "a+", "x+", "c+",
-            "rb", "r+b", "w+b", "a+b", "x+b", "c+b",
-            "rt", "r+t", "w+t", "a+t", "x+t", "c+t",
-        ],
+	/**
+	 * Array of file modes broken into readable and writeable.
+	 *
+	 * @var array<string,array<string>>
+	 */
+	private array $fileModes = [
+		"readable" => [
+			"r", "r+", "w+", "a+", "x+", "c+",
+			"rb", "r+b", "w+b", "a+b", "x+b", "c+b",
+			"rt", "r+t", "w+t", "a+t", "x+t", "c+t",
+		],
 
-        "writeable" => [
-            "w", "w+", "r+", "a", "a+", "x", "x+", "c", "c+",
-            "wb", "w+b", "r+b", "ab", "a+b", "xb", "x+b", "cb", "c+b",
-            "wt", "w+t", "r+t", "at", "a+t", "xt", "x+t", "ct", "c+t",
-        ]
-    ];
+		"writeable" => [
+			"w", "w+", "r+", "a", "a+", "x", "x+", "c", "c+",
+			"wb", "w+b", "r+b", "ab", "a+b", "xb", "x+b", "cb", "c+b",
+			"wt", "w+t", "r+t", "at", "a+t", "xt", "x+t", "ct", "c+t",
+		]
+	];
 
-    /**
-     * Stream resource.
-     *
-     * @var resource|closed-resource|null
-     */
-    protected $resource;
+	/**
+	 * Stream resource.
+	 *
+	 * @var resource|closed-resource|null
+	 */
+	protected $resource;
 
-    /**
-     * ResourceStream constructor.
+	/**
+	 * ResourceStream constructor.
 	 *
 	 * Resource *must* be of type "stream."
-     *
-     * @param resource $resource
-     */
-    public function __construct($resource)
-    {
+	 *
+	 * @param resource $resource
+	 */
+	public function __construct($resource)
+	{
 		/**
 		 * @psalm-suppress RedundantConditionGivenDocblockType
 		 * @psalm-suppress DocblockTypeContradiction
@@ -54,33 +54,33 @@ class ResourceStream implements StreamInterface
 			throw new RuntimeException("Invalid resource supplied in constructor.");
 		}
 
-        $this->resource = $resource;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function __toString(): string
-    {
-        return $this->getContents();
+		$this->resource = $resource;
 	}
 
-    /**
-     * @inheritDoc
-     */
-    public function close(): void
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function __toString(): string
+	{
+		return $this->getContents();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function close(): void
+	{
 		if( \is_resource($this->resource) ){
 			\fclose($this->resource);
 			$this->resource = null;
 		}
-    }
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function detach()
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function detach()
+	{
 		if( !\is_resource($this->resource) ){
 			return null;
 		}
@@ -89,160 +89,169 @@ class ResourceStream implements StreamInterface
 		$this->resource = null;
 
 		return $resource;
-    }
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function getSize(): ?int
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function getSize(): ?int
+	{
 		if( !\is_resource($this->resource) ){
 			return null;
 		}
 
-        $fstat = \fstat($this->resource);
-        return $fstat["size"] ?? null;
-    }
+		$fstat = \fstat($this->resource);
 
-    /**
-     * @inheritDoc
-     */
-    public function tell(): int
-    {
+		if( $fstat === false ){
+			return null;
+		}
+
+		if( !\array_key_exists("size", $fstat) ){
+			return null;
+		}
+
+		return (int) $fstat["size"];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function tell(): int
+	{
 		if( !\is_resource($this->resource) ){
 			throw new RuntimeException("Underlying resource has been detached.");
 		}
 
-        $position = \ftell($this->resource);
+		$position = \ftell($this->resource);
 
-        if( $position === false ){
+		if( $position === false ){
 			throw new RuntimeException("Could not tell position in resource.");
 		}
 
 		return $position;
-    }
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function eof(): bool
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function eof(): bool
+	{
 		if( !\is_resource($this->resource) ){
 			return true;
 		}
 
-        return \feof($this->resource);
-    }
+		return \feof($this->resource);
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function isSeekable(): bool
-    {
-        return (bool) $this->getMetadata('seekable');
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function isSeekable(): bool
+	{
+		return (bool) $this->getMetadata('seekable');
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function seek($offset, $whence = SEEK_SET): void
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function seek($offset, $whence = SEEK_SET): void
+	{
 		if( !\is_resource($this->resource) ||
 			!$this->isSeekable() ){
 			throw new RuntimeException("Resource is not seekable.");
 		}
 
-        if( \fseek($this->resource, $offset, $whence) !== 0 ){
+		if( \fseek($this->resource, $offset, $whence) !== 0 ){
 			throw new RuntimeException("Could not seek resource.");
 		}
-    }
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function rewind(): void
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function rewind(): void
+	{
 		if( !\is_resource($this->resource) ||
 			!$this->isSeekable() ){
 			throw new RuntimeException("Resource is not seekable.");
 		}
 
-        if( \rewind($this->resource) === false ){
+		if( \rewind($this->resource) === false ){
 			throw new RuntimeException("Could not rewind resource.");
 		}
-    }
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function isWritable(): bool
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function isWritable(): bool
+	{
 		/** @psalm-suppress PossiblyInvalidCast */
 		$mode = (string) $this->getMetadata('mode');
 
-        return \in_array(
+		return \in_array(
 			\strtolower($mode),
 			$this->fileModes['writeable']
 		);
-    }
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function write($string): int
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function write($string): int
+	{
 		if( !\is_resource($this->resource) ||
 			!$this->isWritable() ){
 			throw new RuntimeException("Resource is not writable.");
 		}
 
-        $bytes = \fwrite($this->resource, $string);
+		$bytes = \fwrite($this->resource, $string);
 
-        if( $bytes === false ){
+		if( $bytes === false ){
 			throw new RuntimeException("Could not write to resource.");
 		}
 
 		return $bytes;
-    }
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function isReadable(): bool
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function isReadable(): bool
+	{
 		/** @psalm-suppress PossiblyInvalidCast */
 		$mode = (string) $this->getMetadata('mode');
 
-        return \in_array(
+		return \in_array(
 			\strtolower($mode),
 			$this->fileModes['readable']
 		);
-    }
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function read($length): string
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function read($length): string
+	{
 		if( !\is_resource($this->resource) ||
 			!$this->isReadable() ){
 			throw new RuntimeException("Resource is not readable.");
 		}
 
-        $data = \fread($this->resource, $length);
+		$data = \fread($this->resource, $length);
 
-        if( $data === false ){
+		if( $data === false ){
 			throw new RuntimeException("Could not read from resource.");
 		}
 
 		return $data;
-    }
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function getContents(): string
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function getContents(): string
+	{
 		if( !\is_resource($this->resource) ){
 			throw new RuntimeException("Underlying resource has been detached.");
 		}
@@ -257,24 +266,24 @@ class ResourceStream implements StreamInterface
 			throw new RuntimeException("Cannot read from stream.");
 		}
 
-        return $contents;
-    }
+		return $contents;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function getMetadata($key = null)
-    {
+	/**
+	 * @inheritDoc
+	 */
+	public function getMetadata($key = null)
+	{
 		if( !\is_resource($this->resource) ){
 			return $key ? null : [];
 		}
 
-        if( empty($key) ){
-            return \stream_get_meta_data($this->resource);
-        }
+		if( empty($key) ){
+			return \stream_get_meta_data($this->resource);
+		}
 
 		$meta = \stream_get_meta_data($this->resource);
 
 		return $meta[$key] ?? null;
-    }
+	}
 }

--- a/src/Stream/ResourceStream.php
+++ b/src/Stream/ResourceStream.php
@@ -148,7 +148,7 @@ class ResourceStream implements StreamInterface
 	 */
 	public function isSeekable(): bool
 	{
-		return (bool) $this->getMetadata('seekable');
+		return (bool) $this->getMetadata("seekable");
 	}
 
 	/**
@@ -187,11 +187,11 @@ class ResourceStream implements StreamInterface
 	public function isWritable(): bool
 	{
 		/** @psalm-suppress PossiblyInvalidCast */
-		$mode = (string) $this->getMetadata('mode');
+		$mode = (string) $this->getMetadata("mode");
 
 		return \in_array(
 			\strtolower($mode),
-			$this->fileModes['writeable']
+			$this->fileModes["writeable"]
 		);
 	}
 
@@ -220,11 +220,11 @@ class ResourceStream implements StreamInterface
 	public function isReadable(): bool
 	{
 		/** @psalm-suppress PossiblyInvalidCast */
-		$mode = (string) $this->getMetadata('mode');
+		$mode = (string) $this->getMetadata("mode");
 
 		return \in_array(
 			\strtolower($mode),
-			$this->fileModes['readable']
+			$this->fileModes["readable"]
 		);
 	}
 
@@ -278,11 +278,11 @@ class ResourceStream implements StreamInterface
 			return $key ? null : [];
 		}
 
-		if( empty($key) ){
-			return \stream_get_meta_data($this->resource);
-		}
-
 		$meta = \stream_get_meta_data($this->resource);
+
+		if( empty($key) ){
+			return $meta;
+		}
 
 		return $meta[$key] ?? null;
 	}

--- a/src/Stream/ResourceStream.php
+++ b/src/Stream/ResourceStream.php
@@ -37,11 +37,7 @@ class ResourceStream implements StreamInterface
 	protected $resource;
 
 	/**
-	 * ResourceStream constructor.
-	 *
-	 * Resource *must* be of type "stream."
-	 *
-	 * @param resource $resource
+	 * @param resource $resource Resource *must* be of type "stream."
 	 */
 	public function __construct($resource)
 	{

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -2,6 +2,7 @@
 
 namespace Nimbly\Capsule;
 
+use Nimbly\Capsule\Factory\StreamFactory;
 use Nimbly\Capsule\Stream\ResourceStream;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
@@ -33,13 +34,7 @@ class UploadedFile implements UploadedFileInterface
 		protected int $error = UPLOAD_ERR_OK)
 	{
 		if( \is_string($stream) ){
-			$fh = \fopen($stream, "r");
-
-			if( $fh === false ){
-				throw new RuntimeException("Failed to open file for reading.");
-			}
-
-			$stream = new ResourceStream($fh);
+			$stream = StreamFactory::createFromFile($stream, "r");
 		}
 
 		$this->stream = $stream;
@@ -80,13 +75,7 @@ class UploadedFile implements UploadedFileInterface
 			throw new RuntimeException("Target file cannot be empty.");
 		}
 
-		$fh = \fopen($targetPath, "w+");
-
-		if( $fh === false ){
-			throw new RuntimeException("Failed to create target file or it cannot be written to.");
-		}
-
-		$targetStream = new ResourceStream($fh);
+		$targetStream = StreamFactory::createFromFile($targetPath, "w+");
 
 		while( !$this->stream->eof() ){
 			$targetStream->write(

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -3,7 +3,6 @@
 namespace Nimbly\Capsule;
 
 use Nimbly\Capsule\Factory\StreamFactory;
-use Nimbly\Capsule\Stream\ResourceStream;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use RuntimeException;

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -71,7 +71,7 @@ class UploadedFile implements UploadedFileInterface
 
 		$fh = \fopen($targetPath, "w+");
 
-		if( empty($fh) ){
+		if( $fh === false ){
 			throw new RuntimeException("Target file cannot be written to.");
 		}
 

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -14,21 +14,21 @@ class UploadedFile implements UploadedFileInterface
 	 *
 	 * @var boolean
 	 */
-	private $fileMoved = false;
+	private bool $file_moved = false;
 
 	/**
 	 * UploadedFile constructor.
 	 *
 	 * @param StreamInterface $stream
-	 * @param string|null $clientFilename
-	 * @param string|null $clientMediaType
+	 * @param string|null $fileName
+	 * @param string|null $mediaType
 	 * @param integer|null $size
 	 * @param integer $error
 	 */
 	public function __construct(
 		protected StreamInterface $stream,
-		protected ?string $clientFilename = null,
-		protected ?string $clientMediaType = null,
+		protected ?string $fileName = null,
+		protected ?string $mediaType = null,
 		protected ?int $size = null,
 		protected int $error = UPLOAD_ERR_OK)
 	{
@@ -42,7 +42,7 @@ class UploadedFile implements UploadedFileInterface
 	 */
 	private function validateStream(): void
 	{
-		if( $this->error !== UPLOAD_ERR_OK || $this->fileMoved ){
+		if( $this->error !== UPLOAD_ERR_OK || $this->file_moved ){
 			throw new RuntimeException("Underlying stream is not operable.");
 		}
 	}
@@ -82,6 +82,8 @@ class UploadedFile implements UploadedFileInterface
 				$this->stream->read(8192)
 			);
 		}
+
+		$this->file_moved = true;
 	}
 
 	/**
@@ -105,7 +107,7 @@ class UploadedFile implements UploadedFileInterface
 	 */
 	public function getClientFilename(): ?string
 	{
-		return $this->clientFilename;
+		return $this->fileName;
 	}
 
 	/**
@@ -113,6 +115,6 @@ class UploadedFile implements UploadedFileInterface
 	 */
 	public function getClientMediaType(): ?string
 	{
-		return $this->clientMediaType;
+		return $this->mediaType;
 	}
 }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -7,8 +7,8 @@ use Psr\Http\Message\UriInterface;
 class Uri implements UriInterface
 {
 	public function __construct(
-		protected string $scheme,
-		protected string $host,
+		protected ?string $scheme = null,
+		protected ?string $host = null,
 		protected ?string $path = null,
 		protected ?int $port = null,
 		protected ?string $username = null,

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -22,7 +22,7 @@ class Uri implements UriInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function getScheme()
+	public function getScheme(): string
 	{
 		return $this->scheme;
 	}
@@ -30,7 +30,7 @@ class Uri implements UriInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function getAuthority()
+	public function getAuthority(): string
 	{
 		if( empty($this->username) && empty($this->password) ){
 			return "";
@@ -48,7 +48,7 @@ class Uri implements UriInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function getUserInfo()
+	public function getUserInfo(): string
 	{
 		$userInfo = "";
 
@@ -66,7 +66,7 @@ class Uri implements UriInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function getHost()
+	public function getHost(): string
 	{
 		return $this->host;
 	}
@@ -74,7 +74,7 @@ class Uri implements UriInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function getPort()
+	public function getPort(): ?int
 	{
 		return $this->port;
 	}
@@ -82,7 +82,7 @@ class Uri implements UriInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function getPath()
+	public function getPath(): string
 	{
 		return $this->path ?? "";
 	}
@@ -90,7 +90,7 @@ class Uri implements UriInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function getQuery()
+	public function getQuery(): string
 	{
 		return $this->query ?? "";
 	}
@@ -98,7 +98,7 @@ class Uri implements UriInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function getFragment()
+	public function getFragment(): string
 	{
 		return $this->fragment ?? "";
 	}
@@ -106,7 +106,7 @@ class Uri implements UriInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function withScheme($scheme)
+	public function withScheme($scheme): static
 	{
 		$instance = clone $this;
 		$instance->scheme = \strtolower($scheme);
@@ -116,7 +116,7 @@ class Uri implements UriInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function withUserInfo($user, $password = null)
+	public function withUserInfo($user, $password = null): static
 	{
 		$instance = clone $this;
 		$instance->username = $user;
@@ -127,7 +127,7 @@ class Uri implements UriInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function withHost($host)
+	public function withHost($host): static
 	{
 		$instance = clone $this;
 		$instance->host = $host;
@@ -137,7 +137,7 @@ class Uri implements UriInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function withPort($port)
+	public function withPort($port): static
 	{
 		$instance = clone $this;
 		$instance->port = $port;
@@ -147,7 +147,7 @@ class Uri implements UriInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function withPath($path)
+	public function withPath($path): static
 	{
 		$instance = clone $this;
 		$instance->path = $path;
@@ -157,7 +157,7 @@ class Uri implements UriInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function withQuery($query)
+	public function withQuery($query): static
 	{
 		$instance = clone $this;
 		$instance->query = $query;
@@ -168,7 +168,7 @@ class Uri implements UriInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function withFragment($fragment)
+	public function withFragment($fragment): static
 	{
 		$instance = clone $this;
 		$instance->fragment = $fragment;
@@ -178,7 +178,7 @@ class Uri implements UriInterface
 	/**
 	 * @inheritDoc
 	 */
-	public function __toString()
+	public function __toString(): string
 	{
 		$url = "{$this->scheme}://";
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -1,247 +1,207 @@
-<?php declare(strict_types=1);
+<?php
 
-namespace Capsule;
+namespace Nimbly\Capsule;
 
 use Psr\Http\Message\UriInterface;
 
-/**
- * @psalm-suppress MissingConstructor
- */
 class Uri implements UriInterface
 {
-    /**
-     * URI scheme (http or https)
-     *
-     * @var string|null
-     */
-    protected $scheme;
+	public function __construct(
+		protected string $scheme,
+		protected string $host,
+		protected ?string $path = null,
+		protected ?int $port = null,
+		protected ?string $username = null,
+		protected ?string $password = null,
+		protected ?string $query = null,
+		protected ?string $fragment = null
+	)
+	{
+	}
 
-    /**
-     * Request host
-     *
-     * @var string|null
-     */
-    protected $host;
+	/**
+	 * @inheritDoc
+	 */
+	public function getScheme()
+	{
+		return $this->scheme;
+	}
 
-    /**
-     * Port number
-     *
-     * @var int|null
-     */
-    protected $port;
+	/**
+	 * @inheritDoc
+	 */
+	public function getAuthority()
+	{
+		if( empty($this->username) && empty($this->password) ){
+			return "";
+		}
 
-    /**
-     * Username
-     *
-     * @var string|null
-     */
-    protected $username;
+		return \sprintf(
+			"%s:%s@%s:%s",
+			$this->username ?? "",
+			$this->password ?? "",
+			$this->host,
+			$this->port ?? ""
+		);
+	}
 
-    /**
-     * Password
-     *
-     * @var string|null
-     */
-    protected $password;
+	/**
+	 * @inheritDoc
+	 */
+	public function getUserInfo()
+	{
+		$userInfo = "";
 
-    /**
-     * Path
-     *
-     * @var string|null
-     */
-    protected $path;
+		if( $this->username ){
+			$userInfo = $this->username;
+		}
 
-    /**
-     * Query
-     *
-     * @var string|null
-     */
-    protected $query;
+		if( $this->password ){
+			$userInfo .= ":{$this->password}";
+		}
 
-    /**
-     * Fragment
-     *
-     * @var string|null
-     */
-	protected $fragment;
+		return $userInfo;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function getScheme()
-    {
-        return $this->scheme ?? "";
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function getHost()
+	{
+		return $this->host;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function getAuthority()
-    {
-        if( empty($this->username) && empty($this->password) ){
-            return "";
-        }
+	/**
+	 * @inheritDoc
+	 */
+	public function getPort()
+	{
+		return $this->port;
+	}
 
-        return "{$this->username}:{$this->password}@{$this->host}:{$this->port}";
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function getPath()
+	{
+		return $this->path ?? "";
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function getUserInfo()
-    {
-        $userInfo = "";
+	/**
+	 * @inheritDoc
+	 */
+	public function getQuery()
+	{
+		return $this->query ?? "";
+	}
 
-        if( $this->username ){
-            $userInfo = $this->username;
-        }
+	/**
+	 * @inheritDoc
+	 */
+	public function getFragment()
+	{
+		return $this->fragment ?? "";
+	}
 
-        if( $this->password ){
-            $userInfo .= ":{$this->password}";
-        }
+	/**
+	 * @inheritDoc
+	 */
+	public function withScheme($scheme)
+	{
+		$instance = clone $this;
+		$instance->scheme = \strtolower($scheme);
+		return $instance;
+	}
 
-        return $userInfo;
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function withUserInfo($user, $password = null)
+	{
+		$instance = clone $this;
+		$instance->username = $user;
+		$instance->password = $password ?? "";
+		return $instance;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function getHost()
-    {
-        return $this->host ?? "";
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function withHost($host)
+	{
+		$instance = clone $this;
+		$instance->host = $host;
+		return $instance;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function getPort()
-    {
-        return $this->port;
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function withPort($port)
+	{
+		$instance = clone $this;
+		$instance->port = $port;
+		return $instance;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function getPath()
-    {
-        return $this->path ?? "";
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function withPath($path)
+	{
+		$instance = clone $this;
+		$instance->path = $path;
+		return $instance;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function getQuery()
-    {
-        return $this->query ?? "";
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getFragment()
-    {
-        return $this->fragment ?? "";
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function withScheme($scheme)
-    {
-        $instance = clone $this;
-        $instance->scheme = \strtolower($scheme);
-        return $instance;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function withUserInfo($user, $password = null)
-    {
-        $instance = clone $this;
-        $instance->username = $user;
-        $instance->password = $password ?? "";
-        return $instance;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function withHost($host)
-    {
-        $instance = clone $this;
-        $instance->host = $host;
-        return $instance;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function withPort($port)
-    {
-        $instance = clone $this;
-        $instance->port = $port;
-        return $instance;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function withPath($path)
-    {
-        $instance = clone $this;
-        $instance->path = $path;
-        return $instance;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function withQuery($query)
-    {
-        $instance = clone $this;
-        $instance->query = $query;
-        return $instance;
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function withQuery($query)
+	{
+		$instance = clone $this;
+		$instance->query = $query;
+		return $instance;
+	}
 
 
-    /**
-     * @inheritDoc
-     */
-    public function withFragment($fragment)
-    {
-        $instance = clone $this;
-        $instance->fragment = $fragment;
-        return $instance;
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function withFragment($fragment)
+	{
+		$instance = clone $this;
+		$instance->fragment = $fragment;
+		return $instance;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function __toString()
-    {
-        $url = "{$this->scheme}://";
+	/**
+	 * @inheritDoc
+	 */
+	public function __toString()
+	{
+		$url = "{$this->scheme}://";
 
-        if( $this->username || $this->password ){
-            $url .= "{$this->username}:{$this->password}@";
-        }
+		if( $this->username || $this->password ){
+			$url .= "{$this->username}:{$this->password}@";
+		}
 
-        $url .= $this->host ?? "";
+		$url .= $this->host;
 
-        if( $this->port ){
-            $url .= ":{$this->port}";
-        }
+		if( $this->port ){
+			$url .= ":{$this->port}";
+		}
 
-        $url.= ($this->path ?? "/");
+		$url.= ($this->path ?? "/");
 
-        if( $this->query ){
-            $url .= "?{$this->query}";
-        }
+		if( $this->query ){
+			$url .= "?{$this->query}";
+		}
 
-        if( $this->fragment ){
-            $url .= "#{$this->fragment}";
-        }
+		if( $this->fragment ){
+			$url .= "#{$this->fragment}";
+		}
 
-        return $url;
-    }
+		return $url;
+	}
 }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -180,26 +180,39 @@ class Uri implements UriInterface
 	 */
 	public function __toString(): string
 	{
-		$url = "{$this->scheme}://";
+		$url = "";
 
-		if( $this->username || $this->password ){
-			$url .= "{$this->username}:{$this->password}@";
+		if( $this->scheme ){
+			$url .= ($this->scheme . ":");
 		}
 
-		$url .= $this->host;
+		if( $this->getAuthority() ){
+			$url .= ("//" . $this->getAuthority());
+		}
+		else {
+			$url .= ("//" . $this->host);
 
-		if( $this->port ){
-			$url .= ":{$this->port}";
+			if( $this->port ){
+				$url .= (":" . $this->port);
+			}
 		}
 
-		$url.= ($this->path ?? "/");
+		if( empty($this->path) && $this->getAuthority() ){
+			$url .= "/";
+		}
+		elseif( $this->path && !$this->getAuthority() ){
+			$url .= ("/" . \trim($this->path, "/"));
+		}
+		else {
+			$url .= (string) $this->path;
+		}
 
 		if( $this->query ){
-			$url .= "?{$this->query}";
+			$url .= ("?" . $this->query);
 		}
 
 		if( $this->fragment ){
-			$url .= "#{$this->fragment}";
+			$url .= ("#" . $this->fragment);
 		}
 
 		return $url;

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -24,7 +24,7 @@ class Uri implements UriInterface
 	 */
 	public function getScheme(): string
 	{
-		return $this->scheme;
+		return $this->scheme ?? "";
 	}
 
 	/**
@@ -40,7 +40,7 @@ class Uri implements UriInterface
 			"%s:%s@%s:%s",
 			$this->username ?? "",
 			$this->password ?? "",
-			$this->host,
+			$this->host ?? "",
 			$this->port ?? ""
 		);
 	}
@@ -68,7 +68,7 @@ class Uri implements UriInterface
 	 */
 	public function getHost(): string
 	{
-		return $this->host;
+		return $this->host ?? "";
 	}
 
 	/**

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -32,17 +32,23 @@ class Uri implements UriInterface
 	 */
 	public function getAuthority(): string
 	{
-		if( empty($this->username) && empty($this->password) ){
+		if( empty($this->host) ){
 			return "";
 		}
 
-		return \sprintf(
-			"%s:%s@%s:%s",
-			$this->username ?? "",
-			$this->password ?? "",
-			$this->host ?? "",
-			$this->port ?? ""
-		);
+		$authority = "";
+
+		if( !empty($this->username) || !empty($this->password) ){
+			$authority .= \sprintf("%s:%s@", $this->username ?? "", $this->password ?? "");
+		}
+
+		$authority .= $this->host;
+
+		if( $this->port ){
+			$authority .= (":" . $this->port);
+		}
+
+		return $authority;
 	}
 
 	/**
@@ -189,22 +195,12 @@ class Uri implements UriInterface
 		if( $this->getAuthority() ){
 			$url .= ("//" . $this->getAuthority());
 		}
-		else {
-			$url .= ("//" . $this->host);
-
-			if( $this->port ){
-				$url .= (":" . $this->port);
-			}
-		}
 
 		if( empty($this->path) && $this->getAuthority() ){
 			$url .= "/";
 		}
-		elseif( $this->path && !$this->getAuthority() ){
+		elseif( $this->path ) {
 			$url .= ("/" . \trim($this->path, "/"));
-		}
-		else {
-			$url .= (string) $this->path;
 		}
 
 		if( $this->query ){

--- a/tests/BufferStreamTest.php
+++ b/tests/BufferStreamTest.php
@@ -1,15 +1,14 @@
 <?php
 
-namespace Capsule\Tests;
+namespace Nimbly\Capsule\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Capsule\Stream\BufferStream;
+use Nimbly\Capsule\Stream\BufferStream;
 use ReflectionClass;
 use RuntimeException;
-use SebastianBergmann\Environment\Runtime;
 
 /**
- * @covers Capsule\Stream\BufferStream
+ * @covers Nimbly\Capsule\Stream\BufferStream
  */
 class BufferStreamTest extends TestCase
 {

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -1,18 +1,19 @@
 <?php
 
-namespace Capsule\Tests;
+namespace Nimbly\Capsule\Tests;
 
-use Capsule\Request;
-use Capsule\Stream\BufferStream;
+use Nimbly\Capsule\Request;
+use Nimbly\Capsule\Stream\BufferStream;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 /**
- * @covers Capsule\MessageAbstract
- * @covers Capsule\Request
- * @covers Capsule\Stream\BufferStream
- * @covers Capsule\Factory\UriFactory
- * @covers Capsule\Uri
+ * @covers Nimbly\Capsule\MessageAbstract
+ * @covers Nimbly\Capsule\Request
+ * @covers Nimbly\Capsule\Stream\BufferStream
+ * @covers Nimbly\Capsule\Factory\UriFactory
+ * @covers Nimbly\Capsule\Uri
+ * @covers Nimbly\Capsule\Factory\StreamFactory
  */
 class MessageTest extends TestCase
 {

--- a/tests/RequestFactoryTest.php
+++ b/tests/RequestFactoryTest.php
@@ -1,18 +1,19 @@
 <?php
 
-namespace Capsule\Tests;
+namespace Nimbly\Capsule\Tests;
 
-use Capsule\Factory\RequestFactory;
-use Capsule\Request;
+use Nimbly\Capsule\Factory\RequestFactory;
+use Nimbly\Capsule\Request;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Capsule\Factory\RequestFactory
- * @covers Capsule\Request
- * @covers Capsule\Factory\UriFactory
- * @covers Capsule\Uri
- * @covers Capsule\MessageAbstract
- * @covers Capsule\Stream\BufferStream
+ * @covers Nimbly\Capsule\Factory\RequestFactory
+ * @covers Nimbly\Capsule\Request
+ * @covers Nimbly\Capsule\Factory\UriFactory
+ * @covers Nimbly\Capsule\Uri
+ * @covers Nimbly\Capsule\MessageAbstract
+ * @covers Nimbly\Capsule\Stream\BufferStream
+ * @covers Nimbly\Capsule\Factory\StreamFactory
  */
 class RequestFactoryTest extends TestCase
 {

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -98,7 +98,7 @@ class RequestTest extends TestCase
         );
 
         $this->assertEquals("POST", $request->getMethod());
-        $this->assertEquals("http://example.com", (string) $request->getUri());
+        $this->assertEquals("http://example.com/", (string) $request->getUri());
         $this->assertEquals("BODY", $request->getBody()->getContents());
         $this->assertEquals("en_US", $request->getHeader("Accept-Language")[0]);
         $this->assertEquals("2", $request->getProtocolVersion());

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -1,19 +1,20 @@
 <?php
 
-namespace Capsule\Tests;
+namespace Nimbly\Capsule\Tests;
 
-use Capsule\Factory\UriFactory;
-use Capsule\Request;
+use Nimbly\Capsule\Factory\UriFactory;
+use Nimbly\Capsule\Request;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 
 /**
- * @covers Capsule\Request
- * @covers Capsule\Factory\UriFactory
- * @covers Capsule\Uri
- * @covers Capsule\Stream\BufferStream
- * @covers Capsule\Stream\ResourceStream
- * @covers Capsule\MessageAbstract
+ * @covers Nimbly\Capsule\Request
+ * @covers Nimbly\Capsule\Factory\UriFactory
+ * @covers Nimbly\Capsule\Uri
+ * @covers Nimbly\Capsule\Stream\BufferStream
+ * @covers Nimbly\Capsule\Stream\ResourceStream
+ * @covers Nimbly\Capsule\MessageAbstract
+ * @covers Nimbly\Capsule\Factory\StreamFactory
  */
 class RequestTest extends TestCase
 {

--- a/tests/ResourceStreamTest.php
+++ b/tests/ResourceStreamTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Capsule\Tests;
+namespace Nimbly\Capsule\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Capsule\Stream\ResourceStream;
+use Nimbly\Capsule\Stream\ResourceStream;
 use RuntimeException;
 
 /**
- * @covers Capsule\Stream\ResourceStream
+ * @covers Nimbly\Capsule\Stream\ResourceStream
  */
 class ResourceStreamTest extends TestCase
 {

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace Capsule\Tests;
+namespace Nimbly\Capsule\Tests;
 
-use Capsule\Factory\ResponseFactory;
-use Capsule\Response;
-use Capsule\ResponseStatus;
+use Nimbly\Capsule\Factory\ResponseFactory;
+use Nimbly\Capsule\Response;
+use Nimbly\Capsule\ResponseStatus;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Capsule\Factory\ResponseFactory
- * @covers Capsule\Response
- * @covers Capsule\ResponseStatus
- * @covers Capsule\MessageAbstract
- * @covers Capsule\Stream\BufferStream
+ * @covers Nimbly\Capsule\Factory\ResponseFactory
+ * @covers Nimbly\Capsule\Response
+ * @covers Nimbly\Capsule\ResponseStatus
+ * @covers Nimbly\Capsule\MessageAbstract
+ * @covers Nimbly\Capsule\Stream\BufferStream
  */
 class ResponseFactoryTest extends TestCase
 {
@@ -20,21 +20,24 @@ class ResponseFactoryTest extends TestCase
 	{
 		$responseFactory = new ResponseFactory;
 
-		$response = $responseFactory->createResponse(ResponseStatus::OK);
+		$response = $responseFactory->createResponse(200);
 
 		$this->assertInstanceOf(Response::class, $response);
-		$this->assertEquals(ResponseStatus::OK, $response->getStatusCode());
-		$this->assertEquals(ResponseStatus::getPhrase(ResponseStatus::OK), $response->getReasonPhrase());
+		$this->assertEquals(ResponseStatus::OK->value, $response->getStatusCode());
+		$this->assertEquals(ResponseStatus::OK->getPhrase(), $response->getReasonPhrase());
 	}
 
 	public function test_create_response_with_reasonphrase()
 	{
 		$responseFactory = new ResponseFactory;
 
-		$response = $responseFactory->createResponse(ResponseStatus::NOT_FOUND, "Resource not found");
+		$response = $responseFactory->createResponse(
+			ResponseStatus::NOT_FOUND->value,
+			"Resource not found"
+		);
 
 		$this->assertInstanceOf(Response::class, $response);
-		$this->assertEquals(ResponseStatus::NOT_FOUND, $response->getStatusCode());
+		$this->assertEquals(ResponseStatus::NOT_FOUND->value, $response->getStatusCode());
 		$this->assertEquals("Resource not found", $response->getReasonPhrase());
 	}
 }

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Nimbly\Capsule\Factory\ResponseFactory
+ * @covers Nimbly\Capsule\Factory\StreamFactory
  * @covers Nimbly\Capsule\Response
  * @covers Nimbly\Capsule\ResponseStatus
  * @covers Nimbly\Capsule\MessageAbstract

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -23,8 +23,8 @@ class ResponseFactoryTest extends TestCase
 		$response = $responseFactory->createResponse(200);
 
 		$this->assertInstanceOf(Response::class, $response);
-		$this->assertEquals(ResponseStatus::OK->value, $response->getStatusCode());
-		$this->assertEquals(ResponseStatus::OK->getPhrase(), $response->getReasonPhrase());
+		$this->assertEquals(ResponseStatus::OK, $response->getStatusCode());
+		$this->assertEquals(ResponseStatus::getPhrase(ResponseStatus::OK), $response->getReasonPhrase());
 	}
 
 	public function test_create_response_with_reasonphrase()
@@ -32,12 +32,12 @@ class ResponseFactoryTest extends TestCase
 		$responseFactory = new ResponseFactory;
 
 		$response = $responseFactory->createResponse(
-			ResponseStatus::NOT_FOUND->value,
+			ResponseStatus::NOT_FOUND,
 			"Resource not found"
 		);
 
 		$this->assertInstanceOf(Response::class, $response);
-		$this->assertEquals(ResponseStatus::NOT_FOUND->value, $response->getStatusCode());
+		$this->assertEquals(ResponseStatus::NOT_FOUND, $response->getStatusCode());
 		$this->assertEquals("Resource not found", $response->getReasonPhrase());
 	}
 }

--- a/tests/ResponseStatusTest.php
+++ b/tests/ResponseStatusTest.php
@@ -1,24 +1,21 @@
 <?php
 
-namespace Capsule\Tests;
+namespace Nimbly\Capsule\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Capsule\ResponseStatus;
+use Nimbly\Capsule\ResponseStatus;
 
 /**
- * @package Capsule\Tests
- *
- * @covers Capsule\ResponseStatus
+ * @covers Nimbly\Capsule\ResponseStatus
  */
 class ResponseStatusTest extends TestCase
 {
-    public function test_supported_response_code_returns_phrase()
-    {
-        $this->assertNotNull(ResponseStatus::getPhrase(ResponseStatus::CREATED));
-    }
-
-    public function test_unsupported_response_code_returns_null()
-    {
-        $this->assertNull(ResponseStatus::getPhrase(420));
-    }
+	public function test_supported_response_code_returns_phrase()
+	{
+		foreach( ResponseStatus::cases() as $case ){
+			$this->assertNotNull(
+				$case->getPhrase()
+			);
+		}
+	}
 }

--- a/tests/ResponseStatusTest.php
+++ b/tests/ResponseStatusTest.php
@@ -12,10 +12,14 @@ class ResponseStatusTest extends TestCase
 {
 	public function test_supported_response_code_returns_phrase()
 	{
-		foreach( ResponseStatus::cases() as $case ){
-			$this->assertNotNull(
-				$case->getPhrase()
-			);
-		}
+		$this->assertEquals(
+			"Ok",
+			ResponseStatus::getPhrase(ResponseStatus::OK)
+		);
+	}
+
+	public function test_unsupported_response_code_returns_empty_string()
+	{
+		$this->assertEmpty(ResponseStatus::getPhrase(1));
 	}
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\StreamInterface;
  * @covers Nimbly\Capsule\ResponseStatus
  * @covers Nimbly\Capsule\MessageAbstract
  * @covers Nimbly\Capsule\Stream\BufferStream
+ * @covers Nimbly\Capsule\Factory\StreamFactory
  */
 class ResponseTest extends TestCase
 {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -21,7 +21,7 @@ class ResponseTest extends TestCase
         $response = new Response(ResponseStatus::OK);
 
 		$this->assertEquals(
-			ResponseStatus::OK->getPhrase(),
+			ResponseStatus::getPhrase(ResponseStatus::OK),
 			$response->getReasonPhrase()
 		);
     }
@@ -31,12 +31,12 @@ class ResponseTest extends TestCase
         $response = new Response(ResponseStatus::OK);
 
 		$response = $response->withStatus(
-			ResponseStatus::NOT_FOUND->value,
+			ResponseStatus::NOT_FOUND,
 			"Page Not Found"
 		);
 
         $this->assertEquals(
-			ResponseStatus::NOT_FOUND->value,
+			ResponseStatus::NOT_FOUND,
 			$response->getStatusCode()
 		);
 
@@ -51,7 +51,7 @@ class ResponseTest extends TestCase
         $response = new Response(ResponseStatus::NOT_FOUND);
 
 		$this->assertEquals(
-			ResponseStatus::NOT_FOUND->getPhrase(),
+			ResponseStatus::getPhrase(ResponseStatus::NOT_FOUND),
 			$response->getReasonPhrase()
 		);
     }
@@ -59,7 +59,7 @@ class ResponseTest extends TestCase
     public function test_with_status_code_is_immutable()
     {
         $response = new Response(ResponseStatus::OK);
-        $newResponse = $response->withStatus(ResponseStatus::NOT_FOUND->value);
+        $newResponse = $response->withStatus(ResponseStatus::NOT_FOUND);
         $this->assertNotSame($response, $newResponse);
 	}
 
@@ -75,7 +75,7 @@ class ResponseTest extends TestCase
             "2"
         );
 
-        $this->assertEquals(ResponseStatus::CREATED->value, $response->getStatusCode());
+        $this->assertEquals(ResponseStatus::CREATED, $response->getStatusCode());
         $this->assertEquals("OK", $response->getBody()->getContents());
 		$this->assertEquals("text/plain", $response->getHeader('Content-Type')[0]);
 		$this->assertEquals("Reason Phrase", $response->getReasonPhrase());
@@ -88,7 +88,7 @@ class ResponseTest extends TestCase
 
         $this->assertEmpty($response->getBody()->getContents());
 		$this->assertEquals([], $response->getHeaders());
-		$this->assertEquals(ResponseStatus::OK->getPhrase(), $response->getReasonPhrase());
+		$this->assertEquals(ResponseStatus::getPhrase(ResponseStatus::OK), $response->getReasonPhrase());
         $this->assertEquals("1.1", $response->getProtocolVersion());
 	}
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace Capsule\Tests;
+namespace Nimbly\Capsule\Tests;
 
-use Capsule\Response;
-use Capsule\ResponseStatus;
-use Capsule\Stream\BufferStream;
+use Nimbly\Capsule\Response;
+use Nimbly\Capsule\ResponseStatus;
+use Nimbly\Capsule\Stream\BufferStream;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 
 /**
- * @covers Capsule\Response
- * @covers Capsule\ResponseStatus
- * @covers Capsule\MessageAbstract
- * @covers Capsule\Stream\BufferStream
+ * @covers Nimbly\Capsule\Response
+ * @covers Nimbly\Capsule\ResponseStatus
+ * @covers Nimbly\Capsule\MessageAbstract
+ * @covers Nimbly\Capsule\Stream\BufferStream
  */
 class ResponseTest extends TestCase
 {
@@ -21,7 +21,7 @@ class ResponseTest extends TestCase
         $response = new Response(ResponseStatus::OK);
 
 		$this->assertEquals(
-			ResponseStatus::getPhrase(ResponseStatus::OK),
+			ResponseStatus::OK->getPhrase(),
 			$response->getReasonPhrase()
 		);
     }
@@ -29,22 +29,37 @@ class ResponseTest extends TestCase
     public function test_with_status_code_saves_data()
     {
         $response = new Response(ResponseStatus::OK);
-        $response = $response->withStatus(ResponseStatus::NOT_FOUND, "Page Not Found");
 
-        $this->assertEquals(ResponseStatus::NOT_FOUND, $response->getStatusCode());
-        $this->assertEquals("Page Not Found", $response->getReasonPhrase());
+		$response = $response->withStatus(
+			ResponseStatus::NOT_FOUND->value,
+			"Page Not Found"
+		);
+
+        $this->assertEquals(
+			ResponseStatus::NOT_FOUND->value,
+			$response->getStatusCode()
+		);
+
+        $this->assertEquals(
+			"Page Not Found",
+			$response->getReasonPhrase()
+		);
     }
 
     public function test_with_status_code_resolves_phrase_if_none_given()
     {
         $response = new Response(ResponseStatus::NOT_FOUND);
-        $this->assertEquals(ResponseStatus::getPhrase(ResponseStatus::NOT_FOUND), $response->getReasonPhrase());
+
+		$this->assertEquals(
+			ResponseStatus::NOT_FOUND->getPhrase(),
+			$response->getReasonPhrase()
+		);
     }
 
     public function test_with_status_code_is_immutable()
     {
         $response = new Response(ResponseStatus::OK);
-        $newResponse = $response->withStatus(ResponseStatus::NOT_FOUND);
+        $newResponse = $response->withStatus(ResponseStatus::NOT_FOUND->value);
         $this->assertNotSame($response, $newResponse);
 	}
 
@@ -60,7 +75,7 @@ class ResponseTest extends TestCase
             "2"
         );
 
-        $this->assertEquals(ResponseStatus::CREATED, $response->getStatusCode());
+        $this->assertEquals(ResponseStatus::CREATED->value, $response->getStatusCode());
         $this->assertEquals("OK", $response->getBody()->getContents());
 		$this->assertEquals("text/plain", $response->getHeader('Content-Type')[0]);
 		$this->assertEquals("Reason Phrase", $response->getReasonPhrase());
@@ -73,7 +88,7 @@ class ResponseTest extends TestCase
 
         $this->assertEmpty($response->getBody()->getContents());
 		$this->assertEquals([], $response->getHeaders());
-		$this->assertEquals(ResponseStatus::getPhrase(ResponseStatus::OK), $response->getReasonPhrase());
+		$this->assertEquals(ResponseStatus::OK->getPhrase(), $response->getReasonPhrase());
         $this->assertEquals("1.1", $response->getProtocolVersion());
 	}
 

--- a/tests/ServerRequestFactoryTest.php
+++ b/tests/ServerRequestFactoryTest.php
@@ -1,23 +1,24 @@
 <?php
 
-namespace Capsule\Tests;
+namespace Nimbly\Capsule\Tests;
 
-use Capsule\Factory\ServerRequestFactory;
-use Capsule\ServerRequest;
-use Capsule\UploadedFile;
+use Nimbly\Capsule\Factory\ServerRequestFactory;
+use Nimbly\Capsule\ServerRequest;
+use Nimbly\Capsule\UploadedFile;
 use GuzzleHttp\Psr7\ServerRequest as Psr7ServerRequest;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Capsule\Factory\ServerRequestFactory
- * @covers Capsule\ServerRequest
- * @covers Capsule\Request
- * @covers Capsule\MessageAbstract
- * @covers Capsule\Factory\UploadedFileFactory
- * @covers Capsule\UploadedFile
- * @covers Capsule\Factory\UriFactory
- * @covers Capsule\Uri
- * @covers Capsule\Stream\BufferStream
+ * @covers Nimbly\Capsule\MessageAbstract
+ * @covers Nimbly\Capsule\Request
+ * @covers Nimbly\Capsule\ServerRequest
+ * @covers Nimbly\Capsule\UploadedFile
+ * @covers Nimbly\Capsule\Uri
+ * @covers Nimbly\Capsule\Stream\BufferStream
+ * @covers Nimbly\Capsule\Factory\ServerRequestFactory
+ * @covers Nimbly\Capsule\Factory\StreamFactory
+ * @covers Nimbly\Capsule\Factory\UploadedFileFactory
+ * @covers Nimbly\Capsule\Factory\UriFactory
  */
 class ServerRequestFactoryTest extends TestCase
 {
@@ -30,40 +31,40 @@ class ServerRequestFactoryTest extends TestCase
 		$this->assertInstanceOf(ServerRequest::class, $request);
 		$this->assertEquals("GET", $request->getMethod());
 		$this->assertEquals("example.com", $request->getUri()->getHost());
-		$this->assertEquals('http', $request->getUri()->getScheme());
+		$this->assertEquals("http", $request->getUri()->getScheme());
 	}
 
 	public function test_create_from_globals()
 	{
-		$_SERVER['SERVER_PROTOCOL'] = "HTTP/1.1";
-		$_SERVER['REQUEST_METHOD'] = "POST";
-		$_SERVER['REQUEST_URI'] = "/foo?query1=value1";
-		$_SERVER['HTTP_HOST'] = "capsule.org";
-		$_SERVER['HTTP_CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
-		$_SERVER['HTTP_X_FORWARDED_BY'] = '5.6.7.8';
+		$_SERVER["SERVER_PROTOCOL"] = "HTTP/1.1";
+		$_SERVER["REQUEST_METHOD"] = "POST";
+		$_SERVER["REQUEST_URI"] = "/foo?query1=value1";
+		$_SERVER["HTTP_HOST"] = "capsule.org";
+		$_SERVER["HTTP_CONTENT_TYPE"] = "application/x-www-form-urlencoded";
+		$_SERVER["HTTP_X_FORWARDED_BY"] = "5.6.7.8";
 		$_GET = ["query1" => "value1"];
 		$_POST = ["post1" => "value1"];
 		$_COOKIE = ["cookie1" => "value1"];
 
 		$_FILES = [
 			[
-				'name' => 'file1.json',
-				'type' => 'text/plain',
-				'tmp_name' => 'test.json',
-				'size' => 100,
-				'error' => UPLOAD_ERR_OK
+				"name" => "file1.json",
+				"type" => "text/plain",
+				"tmp_name" => "test.json",
+				"size" => 100,
+				"error" => UPLOAD_ERR_OK
 			]
 		];
 
 		$request = ServerRequestFactory::createFromGlobals();
 
 		$this->assertEquals(
-			'1.1',
+			"1.1",
 			$request->getProtocolVersion()
 		);
 
 		$this->assertEquals(
-			'POST',
+			"POST",
 			$request->getMethod()
 		);
 
@@ -83,7 +84,7 @@ class ServerRequestFactoryTest extends TestCase
 		);
 
 		$this->assertEquals(
-			['query1' => 'value1'],
+			["query1" => "value1"],
 			$request->getQueryParams()
 		);
 
@@ -99,7 +100,7 @@ class ServerRequestFactoryTest extends TestCase
 
 		$this->assertEquals(
 			[
-				new UploadedFile('test.json', 'file1.json', 'text/plain', 100, UPLOAD_ERR_OK)
+				new UploadedFile("test.json", "file1.json", "text/plain", 100, UPLOAD_ERR_OK)
 			],
 			$request->getUploadedFiles()
 		);

--- a/tests/ServerRequestFactoryTest.php
+++ b/tests/ServerRequestFactoryTest.php
@@ -6,7 +6,10 @@ use Nimbly\Capsule\Factory\ServerRequestFactory;
 use Nimbly\Capsule\ServerRequest;
 use Nimbly\Capsule\UploadedFile;
 use GuzzleHttp\Psr7\ServerRequest as Psr7ServerRequest;
+use Nimbly\Capsule\Stream\BufferStream;
+use Nimbly\Capsule\Stream\ResourceStream;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * @covers Nimbly\Capsule\MessageAbstract
@@ -15,6 +18,7 @@ use PHPUnit\Framework\TestCase;
  * @covers Nimbly\Capsule\UploadedFile
  * @covers Nimbly\Capsule\Uri
  * @covers Nimbly\Capsule\Stream\BufferStream
+ * @covers Nimbly\Capsule\Stream\ResourceStream
  * @covers Nimbly\Capsule\Factory\ServerRequestFactory
  * @covers Nimbly\Capsule\Factory\StreamFactory
  * @covers Nimbly\Capsule\Factory\UploadedFileFactory
@@ -50,7 +54,7 @@ class ServerRequestFactoryTest extends TestCase
 			[
 				"name" => "file1.json",
 				"type" => "text/plain",
-				"tmp_name" => "test.json",
+				"tmp_name" => __DIR__ . "/fixtures/test.json",
 				"size" => 100,
 				"error" => UPLOAD_ERR_OK
 			]
@@ -98,11 +102,31 @@ class ServerRequestFactoryTest extends TestCase
 			$request->getParsedBody()
 		);
 
+		$this->assertCount(1, $request->getUploadedFiles());
+
 		$this->assertEquals(
-			[
-				new UploadedFile("test.json", "file1.json", "text/plain", 100, UPLOAD_ERR_OK)
-			],
-			$request->getUploadedFiles()
+			"file1.json",
+			$request->getUploadedFiles()[0]->getClientFilename()
+		);
+
+		$this->assertEquals(
+			"text/plain",
+			$request->getUploadedFiles()[0]->getClientMediaType()
+		);
+
+		$this->assertEquals(
+			100,
+			$request->getUploadedFiles()[0]->getSize()
+		);
+
+		$this->assertEquals(
+			UPLOAD_ERR_OK,
+			$request->getUploadedFiles()[0]->getError()
+		);
+
+		$this->assertEquals(
+			"{\"name\": \"Test\", \"email\": \"test@example.com\"}",
+			$request->getUploadedFiles()[0]->getStream()->getContents()
 		);
 
 		$this->assertEquals(

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -1,31 +1,33 @@
 <?php
 
-namespace Capsule\Tests;
+namespace Nimbly\Capsule\Tests;
 
-use Capsule\Factory\UriFactory;
-use Capsule\ServerRequest;
-use Capsule\Stream\BufferStream;
-use Capsule\UploadedFile;
+use Nimbly\Capsule\Factory\UriFactory;
+use Nimbly\Capsule\ServerRequest;
+use Nimbly\Capsule\Stream\BufferStream;
+use Nimbly\Capsule\UploadedFile;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Capsule\ServerRequest
- * @covers Capsule\Request
- * @covers Capsule\Factory\UriFactory
- * @covers Capsule\Uri
- * @covers Capsule\Stream\BufferStream
- * @covers Capsule\MessageAbstract
- * @covers Capsule\UploadedFile
+ * @covers Nimbly\Capsule\ServerRequest
+ * @covers Nimbly\Capsule\Request
+ * @covers Nimbly\Capsule\Factory\UriFactory
+ * @covers Nimbly\Capsule\Uri
+ * @covers Nimbly\Capsule\Stream\BufferStream
+ * @covers Nimbly\Capsule\MessageAbstract
+ * @covers Nimbly\Capsule\UploadedFile
+ * @covers Nimbly\Capsule\Factory\StreamFactory
  */
 class ServerRequestTest extends TestCase
 {
-	public function makeRequest(): ServerRequest
+	private function makeRequest(): ServerRequest
 	{
-		return new ServerRequest(
+		$serverRequest = new ServerRequest(
 			"GET",
 			"http://example.org/foo/bar?q=search",
-			['name' => "Test User", "email" => "test@example.com"],
-			//'{"name": "Test User", "email": "test@example.com"}',
+			null,
+			//["name" => "Test User", "email" => "test@example.com"],
+			//"{"name": "Test User", "email": "test@example.com"}",
 			[
 				"query1" => "value1",
 				"query2" => "value2"
@@ -40,9 +42,9 @@ class ServerRequestTest extends TestCase
 			],
 			[
 				new UploadedFile(
-					'file1',
-					'text/plain',
-					'temp_file.name',
+					"file1",
+					"text/plain",
+					"temp_file.name",
 					100,
 					UPLOAD_ERR_OK
 				)
@@ -50,6 +52,8 @@ class ServerRequestTest extends TestCase
 			[],
 			"1.1"
 		);
+
+		return $serverRequest->withParsedBody(["name" => "Test User", "email" => "test@example.com"]);
 	}
 
 	public function test_create_with_uri_instance()
@@ -75,40 +79,6 @@ class ServerRequestTest extends TestCase
 		$this->assertInstanceOf(
 			BufferStream::class,
 			$request->getBody()
-		);
-	}
-
-	public function test_create_with_array_body()
-	{
-		$request = new ServerRequest(
-			"get",
-			"http://example.org/foo/bar?q=search",
-			["email" => "test@example.com", "name" => "Testy Test"]
-		);
-
-		$this->assertEquals(
-			[
-				"email" => "test@example.com",
-				"name" => "Testy Test"
-			],
-			$request->getParsedBody()
-		);
-	}
-
-	public function test_create_with_object_body()
-	{
-		$request = new ServerRequest(
-			"get",
-			"http://example.org/foo/bar?q=search",
-			(object) ["email" => "test@example.com", "name" => "Testy Test"]
-		);
-
-		$this->assertEquals(
-			(object) [
-				"email" => "test@example.com",
-				"name" => "Testy Test"
-			],
-			$request->getParsedBody()
 		);
 	}
 
@@ -157,14 +127,14 @@ class ServerRequestTest extends TestCase
 		$request = $this->makeRequest();
 
 		$request = $request->withCookieParams([
-			'cookie3' => 'value3',
-			'cookie4' => 'value4'
+			"cookie3" => "value3",
+			"cookie4" => "value4"
 		]);
 
 		$this->assertEquals(
 			[
-				'cookie3' => 'value3',
-				'cookie4' => 'value4'
+				"cookie3" => "value3",
+				"cookie4" => "value4"
 			],
 			$request->getCookieParams()
 		);
@@ -214,9 +184,9 @@ class ServerRequestTest extends TestCase
 		$this->assertEquals(
 			[
 				new UploadedFile(
-					'file1',
-					'text/plain',
-					'temp_file.name',
+					"file1",
+					"text/plain",
+					"temp_file.name",
 					100,
 					UPLOAD_ERR_OK
 				)
@@ -330,21 +300,21 @@ class ServerRequestTest extends TestCase
 	{
 		$request = $this->makeRequest();
 
-		$this->assertTrue($request->hasBodyParam('name'));
+		$this->assertTrue($request->hasBodyParam("name"));
 	}
 
 	public function test_has_query_param()
 	{
 		$request = $this->makeRequest();
 
-		$this->assertTrue($request->hasQueryParam('query1'));
+		$this->assertTrue($request->hasQueryParam("query1"));
 	}
 
 	public function test_get_query_param()
 	{
 		$request = $this->makeRequest();
 
-		$this->assertEquals('value1', $request->getQueryParam('query1'));
+		$this->assertEquals("value1", $request->getQueryParam("query1"));
 	}
 
 	public function test_get_body_param_from_array_parsed_body()
@@ -357,7 +327,7 @@ class ServerRequestTest extends TestCase
 			]
 		);
 
-		$this->assertEquals("test@nimbly.io", $request->getBodyParam('email'));
+		$this->assertEquals("test@nimbly.io", $request->getBodyParam("email"));
 	}
 
 	public function test_get_body_param_from_object_parsed_body()
@@ -370,7 +340,7 @@ class ServerRequestTest extends TestCase
 			]
 		);
 
-		$this->assertEquals("test@nimbly.io", $request->getBodyParam('email'));
+		$this->assertEquals("test@nimbly.io", $request->getBodyParam("email"));
 	}
 
 	public function test_get_body_param_returns_null_if_not_found()
@@ -383,7 +353,7 @@ class ServerRequestTest extends TestCase
 			]
 		);
 
-		$this->assertNull($request->getBodyParam('id'));
+		$this->assertNull($request->getBodyParam("id"));
 	}
 
 	public function test_only_body_params()
@@ -465,8 +435,8 @@ class ServerRequestTest extends TestCase
 
 		$this->assertEquals(
 			[
-				'name' => 'Test User',
-				'email' => 'test@example.com',
+				"name" => "Test User",
+				"email" => "test@example.com",
 				"query1" => "value1",
 				"query2" => "value2",
 				"q" => "search"

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -42,7 +42,7 @@ class ServerRequestTest extends TestCase
 			],
 			[
 				new UploadedFile(
-					"file1",
+					new BufferStream("Capsule!"),
 					"text/plain",
 					"temp_file.name",
 					100,
@@ -184,7 +184,7 @@ class ServerRequestTest extends TestCase
 		$this->assertEquals(
 			[
 				new UploadedFile(
-					"file1",
+					new BufferStream("Capsule!"),
 					"text/plain",
 					"temp_file.name",
 					100,
@@ -201,8 +201,8 @@ class ServerRequestTest extends TestCase
 		$request = $this->makeRequest();
 
 		$newRequest = $request->withUploadedFiles([
-			new UploadedFile("example1.file", "appliication/json", "foo", 101, UPLOAD_ERR_OK),
-			new UploadedFile("example2.file", "appliication/json", "bar", 201, UPLOAD_ERR_NO_FILE)
+			new UploadedFile(new BufferStream, "appliication/json", "foo", 101, UPLOAD_ERR_OK),
+			new UploadedFile(new BufferStream, "appliication/json", "bar", 201, UPLOAD_ERR_NO_FILE)
 		]);
 
 		$this->assertNotSame(
@@ -212,8 +212,8 @@ class ServerRequestTest extends TestCase
 
 		$this->assertEquals(
 			[
-				new UploadedFile("example1.file", "appliication/json", "foo", 101, UPLOAD_ERR_OK),
-				new UploadedFile("example2.file", "appliication/json", "bar", 201, UPLOAD_ERR_NO_FILE)
+				new UploadedFile(new BufferStream, "appliication/json", "foo", 101, UPLOAD_ERR_OK),
+				new UploadedFile(new BufferStream, "appliication/json", "bar", 201, UPLOAD_ERR_NO_FILE)
 			],
 			$newRequest->getUploadedFiles()
 		);
@@ -402,7 +402,9 @@ class ServerRequestTest extends TestCase
 	{
 		$request = $this->makeRequest();
 
-		$uploadedFile = new UploadedFile("Ok");
+		$uploadedFile = new UploadedFile(
+			new BufferStream("Capsule!")
+		);
 
 		$request = $request->withUploadedFiles([
 			"file" => $uploadedFile
@@ -417,7 +419,9 @@ class ServerRequestTest extends TestCase
 	{
 		$request = $this->makeRequest();
 
-		$uploadedFile = new UploadedFile("Ok");
+		$uploadedFile = new UploadedFile(
+			new BufferStream
+		);
 
 		$request = $request->withUploadedFiles([
 			"file" => $uploadedFile

--- a/tests/StreamFactoryTest.php
+++ b/tests/StreamFactoryTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Capsule\Stream;
+namespace Nimbly\Capsule\Stream;
 
-use Capsule\Factory\StreamFactory;
+use Nimbly\Capsule\Factory\StreamFactory;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 /**
- * @covers Capsule\Factory\StreamFactory
- * @covers Capsule\Stream\ResourceStream
+ * @covers Nimbly\Capsule\Factory\StreamFactory
+ * @covers Nimbly\Capsule\Stream\ResourceStream
  */
 class StreamFactoryTest extends TestCase
 {

--- a/tests/UploadedFileFactoryTest.php
+++ b/tests/UploadedFileFactoryTest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Capsule\Tests;
+namespace Nimbly\Capsule\Tests;
 
-use Capsule\Factory\UploadedFileFactory;
-use Capsule\Stream\BufferStream;
-use Capsule\UploadedFile;
+use Nimbly\Capsule\Factory\UploadedFileFactory;
+use Nimbly\Capsule\Stream\BufferStream;
+use Nimbly\Capsule\UploadedFile;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Capsule\Factory\UploadedFileFactory
- * @covers Capsule\UploadedFile
- * @covers Capsule\Stream\BufferStream
+ * @covers Nimbly\Capsule\Factory\UploadedFileFactory
+ * @covers Nimbly\Capsule\UploadedFile
+ * @covers Nimbly\Capsule\Stream\BufferStream
  */
 class UploadedFileFactoryTest extends TestCase
 {

--- a/tests/UploadedFileFactoryTest.php
+++ b/tests/UploadedFileFactoryTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
  * @covers Nimbly\Capsule\Factory\UploadedFileFactory
  * @covers Nimbly\Capsule\UploadedFile
  * @covers Nimbly\Capsule\Stream\BufferStream
+ * @covers Nimbly\Capsule\Stream\ResourceStream
  */
 class UploadedFileFactoryTest extends TestCase
 {

--- a/tests/UploadedFileFactoryTest.php
+++ b/tests/UploadedFileFactoryTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 /**
+ * @covers Nimbly\Capsule\Factory\StreamFactory
  * @covers Nimbly\Capsule\Factory\UploadedFileFactory
  * @covers Nimbly\Capsule\UploadedFile
  * @covers Nimbly\Capsule\Stream\BufferStream

--- a/tests/UploadedFileFactoryTest.php
+++ b/tests/UploadedFileFactoryTest.php
@@ -6,6 +6,7 @@ use Nimbly\Capsule\Factory\UploadedFileFactory;
 use Nimbly\Capsule\Stream\BufferStream;
 use Nimbly\Capsule\UploadedFile;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 /**
  * @covers Nimbly\Capsule\Factory\UploadedFileFactory
@@ -56,5 +57,18 @@ class UploadedFileFactoryTest extends TestCase
 		$this->assertEquals("text/json", $uploadedFile->getClientMediaType());
 		$this->assertEquals(\filesize(__DIR__ . "/tmp/tmp_upload"), $uploadedFile->getSize());
 		$this->assertEquals(UPLOAD_ERR_OK, $uploadedFile->getError());
+	}
+
+	public function test_create_from_global_file_open_error_throws_runtime_exception()
+	{
+		$this->expectException(RuntimeException::class);
+
+		$uploadedFile = UploadedFileFactory::createFromGlobal([
+			"tmp_name" => "foo",
+			"name" => "test.json",
+			"type" => "text/json",
+			"size" => \filesize(__DIR__ . "/tmp/tmp_upload"),
+			"error" => UPLOAD_ERR_OK
+		]);
 	}
 }

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Capsule\Tests;
+namespace Nimbly\Capsule\Tests;
 
-use Capsule\Stream\BufferStream;
-use Capsule\Stream\ResourceStream;
-use Capsule\UploadedFile;
+use Nimbly\Capsule\Stream\BufferStream;
+use Nimbly\Capsule\Stream\ResourceStream;
+use Nimbly\Capsule\UploadedFile;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 /**
- * @covers Capsule\UploadedFile
- * @covers Capsule\Stream\ResourceStream
- * @covers Capsule\Stream\BufferStream
+ * @covers Nimbly\Capsule\UploadedFile
+ * @covers Nimbly\Capsule\Stream\ResourceStream
+ * @covers Nimbly\Capsule\Stream\BufferStream
  */
 class UploadedFileTest extends TestCase
 {
@@ -28,17 +28,11 @@ class UploadedFileTest extends TestCase
 		}
 
 		return new UploadedFile(
-			__DIR__ . "/tmp/tmp_upload",
+			new ResourceStream(\fopen(__DIR__ . "/tmp/tmp_upload", "r")),
 			"test.json",
 			"text/plain",
 			\filesize(__DIR__ . "/tmp/tmp_upload")
 		);
-	}
-
-	public function test_constructor_with_invalid_upload_content()
-	{
-		$this->expectException(RuntimeException::class);
-		new UploadedFile(new \stdClass);
 	}
 
 	public function test_get_stream_from_stream()
@@ -57,14 +51,6 @@ class UploadedFileTest extends TestCase
 		$uploadedFile = $this->makeFile();
 
 		$this->assertTrue($uploadedFile->getStream() instanceof ResourceStream);
-	}
-
-	public function test_get_stream_from_empty_file()
-	{
-		$uploadedFile = new UploadedFile("");
-
-		$this->expectException(RuntimeException::class);
-		$uploadedFile->getStream();
 	}
 
 	public function test_move_to()

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -64,12 +64,20 @@ class UploadedFileTest extends TestCase
 		);
 	}
 
-	public function test_move_to_invalid_target_path()
+	public function test_move_to_empty_target_path_throws_runtime_exception()
 	{
 		$uploadedFile = $this->makeFile();
 
 		$this->expectException(RuntimeException::class);
 		$uploadedFile->moveTo("");
+	}
+
+	public function test_move_to_unwriteable_target_throws_runtime_exception()
+	{
+		$uploadedFile = $this->makeFile();
+
+		$this->expectException(RuntimeException::class);
+		$uploadedFile->moveTo("/root");
 	}
 
 	public function test_calling_move_to_more_than_once_throws_exception()

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -6,6 +6,7 @@ use Nimbly\Capsule\Stream\BufferStream;
 use Nimbly\Capsule\Stream\ResourceStream;
 use Nimbly\Capsule\UploadedFile;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 
 /**
@@ -35,7 +36,7 @@ class UploadedFileTest extends TestCase
 		);
 	}
 
-	public function test_get_stream_from_stream()
+	public function test_get_stream_from_stream(): void
 	{
 		$stream = new BufferStream("Capsule!");
 		$uploadedFile = new UploadedFile($stream);
@@ -46,14 +47,21 @@ class UploadedFileTest extends TestCase
 		);
 	}
 
-	public function test_get_stream_from_file()
+	public function test_create_from_file_path(): void
+	{
+		$uploadedFile = new UploadedFile(__DIR__ . "/fixtures/test.json");
+
+		$this->assertInstanceOf(StreamInterface::class, $uploadedFile->getStream());
+	}
+
+	public function test_get_stream_from_file(): void
 	{
 		$uploadedFile = $this->makeFile();
 
-		$this->assertTrue($uploadedFile->getStream() instanceof ResourceStream);
+		$this->assertInstanceOf(ResourceStream::class, $uploadedFile->getStream());
 	}
 
-	public function test_move_to()
+	public function test_move_to(): void
 	{
 		$uploadedFile = $this->makeFile();
 
@@ -64,7 +72,7 @@ class UploadedFileTest extends TestCase
 		);
 	}
 
-	public function test_move_to_empty_target_path_throws_runtime_exception()
+	public function test_move_to_empty_target_path_throws_runtime_exception(): void
 	{
 		$uploadedFile = $this->makeFile();
 
@@ -72,7 +80,7 @@ class UploadedFileTest extends TestCase
 		$uploadedFile->moveTo("");
 	}
 
-	public function test_move_to_unwriteable_target_throws_runtime_exception()
+	public function test_move_to_unwriteable_target_throws_runtime_exception(): void
 	{
 		$uploadedFile = $this->makeFile();
 
@@ -80,7 +88,7 @@ class UploadedFileTest extends TestCase
 		$uploadedFile->moveTo("/root");
 	}
 
-	public function test_calling_move_to_more_than_once_throws_exception()
+	public function test_calling_move_to_more_than_once_throws_exception(): void
 	{
 		$uploadedFile = $this->makeFile();
 		$uploadedFile->moveTo(__DIR__ . "/tmp/" . $uploadedFile->getClientFilename());
@@ -89,14 +97,14 @@ class UploadedFileTest extends TestCase
 		$uploadedFile->moveTo(__DIR__ . "/tmp/" . $uploadedFile->getClientFilename());
 	}
 
-	public function test_get_size()
+	public function test_get_size(): void
 	{
 		$uploadedFile = $this->makeFile();
 
 		$this->assertEquals(45, $uploadedFile->getSize());
 	}
 
-	public function test_get_error()
+	public function test_get_error(): void
 	{
 		$uploadedFile = $this->makeFile();
 
@@ -106,7 +114,7 @@ class UploadedFileTest extends TestCase
 		);
 	}
 
-	public function test_get_client_filename()
+	public function test_get_client_filename(): void
 	{
 		$uploadedFile = $this->makeFile();
 
@@ -116,7 +124,7 @@ class UploadedFileTest extends TestCase
 		);
 	}
 
-	public function test_get_client_media_type()
+	public function test_get_client_media_type(): void
 	{
 		$uploadedFile = $this->makeFile();
 
@@ -126,7 +134,7 @@ class UploadedFileTest extends TestCase
 		);
 	}
 
-	public function test_getting_stream_after_moving_should_throw_exception()
+	public function test_getting_stream_after_moving_should_throw_exception(): void
 	{
 		$uploadedFile = $this->makeFile();
 		$uploadedFile->moveTo(__DIR__ . "/tmp/" . $uploadedFile->getClientFilename());

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -13,6 +13,7 @@ use RuntimeException;
  * @covers Nimbly\Capsule\UploadedFile
  * @covers Nimbly\Capsule\Stream\ResourceStream
  * @covers Nimbly\Capsule\Stream\BufferStream
+ * @covers Nimbly\Capsule\Factory\StreamFactory
  */
 class UploadedFileTest extends TestCase
 {

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -54,6 +54,12 @@ class UploadedFileTest extends TestCase
 		$this->assertInstanceOf(StreamInterface::class, $uploadedFile->getStream());
 	}
 
+	public function test_create_from_non_readable_file_path_throws_runtime_exception(): void
+	{
+		$this->expectException(RuntimeException::class);
+		$uploadedFile = new UploadedFile(__DIR__ . "/fixtures/foo.json");
+	}
+
 	public function test_get_stream_from_file(): void
 	{
 		$uploadedFile = $this->makeFile();

--- a/tests/UriFactoryTest.php
+++ b/tests/UriFactoryTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Capsule\Tests;
+namespace Nimbly\Capsule\Tests;
 
-use Capsule\Factory\UriFactory;
+use Nimbly\Capsule\Factory\UriFactory;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Capsule\Factory\UriFactory
- * @covers Capsule\Uri
+ * @covers Nimbly\Capsule\Factory\UriFactory
+ * @covers Nimbly\Capsule\Uri
  */
 class UriFactoryTest extends TestCase
 {

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -1,69 +1,72 @@
 <?php
 
-namespace Capsule\Tests;
+namespace Nimbly\Capsule\Tests;
 
+use Nimbly\Capsule\Factory\UriFactory;
 use PHPUnit\Framework\TestCase;
-use Capsule\Uri;
 
 /**
- * @covers Capsule\Uri
+ * @covers Nimbly\Capsule\Uri
+ * @covers Nimbly\Capsule\Factory\UriFactory
  */
 class UriTest extends TestCase
 {
     public function test_with_scheme_saves_data()
     {
-        $uri = (new Uri)->withScheme("https");
+		$uri = UriFactory::createFromString("http://example.com:80");
+        $uri = $uri->withScheme("https");
         $this->assertEquals("https", $uri->getScheme());
     }
 
     public function test_with_scheme_is_immutable()
     {
-        $uri = new Uri;
+        $uri = UriFactory::createFromString("example.com");
         $newUri = $uri->withScheme("https");
 
-        $this->assertEmpty($uri->getScheme());
         $this->assertNotEquals($uri, $newUri);
     }
 
     public function test_with_userinfo_saves_data()
     {
-        $uri = (new Uri)->withUserInfo("username", "password");
+		$uri = UriFactory::createFromString("http://example.com:80");
+        $uri = $uri->withUserInfo("username", "password");
         $this->assertEquals("username:password", $uri->getUserInfo());
     }
 
     public function test_with_userinfo_is_immutable()
     {
-        $uri = new Uri;
+        $uri = UriFactory::createFromString("http://example.com");
         $newUri = $uri->withUserInfo("username", "password");
 
-        $this->assertEmpty($uri->getScheme());
+        $this->assertEmpty($uri->getUserInfo());
         $this->assertNotEquals($uri, $newUri);
     }
 
     public function test_with_host_saves_data()
     {
-        $uri = (new Uri)->withHost("www.example.com");
+		$uri = UriFactory::createFromString("http://example.com:80");
+        $uri = $uri->withHost("www.example.com");
         $this->assertEquals("www.example.com", $uri->getHost());
     }
 
     public function test_with_host_is_immutable()
     {
-        $uri = new Uri;
+        $uri = UriFactory::createFromString("http://example.com");
         $newUri = $uri->withHost("www.example.com");
 
-        $this->assertEmpty($uri->getHost());
         $this->assertNotEquals($uri, $newUri);
     }
 
     public function test_with_port_saves_data()
     {
-        $uri = (new Uri)->withPort(443);
+		$uri = UriFactory::createFromString("http://example.com:80");
+        $uri = $uri->withPort(443);
         $this->assertEquals(443, $uri->getPort());
     }
 
     public function test_with_port_is_immutable()
     {
-        $uri = new Uri;
+        $uri = UriFactory::createFromString("http://example.com");
         $newUri = $uri->withPort(443);
 
         $this->assertEmpty($uri->getPort());
@@ -72,13 +75,14 @@ class UriTest extends TestCase
 
     public function test_with_path_saves_data()
     {
-        $uri = (new Uri)->withPath("/some/path/to/resource");
+		$uri = UriFactory::createFromString("http://example.com:80");
+        $uri = $uri->withPath("/some/path/to/resource");
         $this->assertEquals("/some/path/to/resource", $uri->getPath());
     }
 
     public function test_with_path_is_immutable()
     {
-        $uri = new Uri;
+        $uri = UriFactory::createFromString("http://example.com:80");
         $newUri = $uri->withPath("/some/path/to/resource");
 
         $this->assertEmpty($uri->getPath());
@@ -87,13 +91,13 @@ class UriTest extends TestCase
 
     public function test_with_query_saves_data()
     {
-        $uri = (new Uri)->withQuery("q=foo&s=some search text");
+		$uri = UriFactory::createFromString("http://example.com:80?q=foo&s=some search text");
         $this->assertEquals("q=foo&s=some search text", $uri->getQuery());
     }
 
     public function test_with_query_is_immutable()
     {
-        $uri = new Uri;
+        $uri = UriFactory::createFromString("http://example.com:80");
         $newUri = $uri->withQuery("q=foo&s=some search text");
 
         $this->assertEmpty($uri->getQuery());
@@ -102,13 +106,14 @@ class UriTest extends TestCase
 
     public function test_with_fragment_saves_data()
     {
-        $uri = (new Uri)->withFragment("Chapter1");
+		$uri = UriFactory::createFromString("http://example.com:80");
+        $uri = $uri->withFragment("Chapter1");
         $this->assertEquals("Chapter1", $uri->getFragment());
     }
 
     public function test_with_fragment_is_immutable()
     {
-        $uri = new Uri;
+        $uri = UriFactory::createFromString("http://example.com:80");
         $newUri = $uri->withFragment("Chapter1");
 
         $this->assertEmpty($uri->getFragment());
@@ -117,7 +122,7 @@ class UriTest extends TestCase
 
     public function test_get_authority_with_no_credentials_returns_empty_string()
     {
-		$uri = new Uri;
+		$uri = UriFactory::createFromString("http://example.com:80");
         $this->assertEquals("", $uri->getAuthority());
     }
 }

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -3,6 +3,7 @@
 namespace Nimbly\Capsule\Tests;
 
 use Nimbly\Capsule\Factory\UriFactory;
+use Nimbly\Capsule\Uri;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -11,118 +12,122 @@ use PHPUnit\Framework\TestCase;
  */
 class UriTest extends TestCase
 {
-    public function test_with_scheme_saves_data()
-    {
+	public function test_with_scheme_saves_data()
+	{
 		$uri = UriFactory::createFromString("http://example.com:80");
-        $uri = $uri->withScheme("https");
-        $this->assertEquals("https", $uri->getScheme());
-    }
+		$uri = $uri->withScheme("https");
+		$this->assertEquals("https", $uri->getScheme());
+	}
 
-    public function test_with_scheme_is_immutable()
-    {
-        $uri = UriFactory::createFromString("example.com");
-        $newUri = $uri->withScheme("https");
+	public function test_with_scheme_is_immutable()
+	{
+		$uri = UriFactory::createFromString("example.com");
+		$newUri = $uri->withScheme("https");
 
-        $this->assertNotEquals($uri, $newUri);
-    }
+		$this->assertNotEquals($uri, $newUri);
+	}
 
-    public function test_with_userinfo_saves_data()
-    {
+	public function test_with_userinfo_saves_data()
+	{
 		$uri = UriFactory::createFromString("http://example.com:80");
-        $uri = $uri->withUserInfo("username", "password");
-        $this->assertEquals("username:password", $uri->getUserInfo());
-    }
+		$uri = $uri->withUserInfo("username", "password");
+		$this->assertEquals("username:password", $uri->getUserInfo());
+	}
 
-    public function test_with_userinfo_is_immutable()
-    {
-        $uri = UriFactory::createFromString("http://example.com");
-        $newUri = $uri->withUserInfo("username", "password");
+	public function test_with_userinfo_is_immutable()
+	{
+		$uri = UriFactory::createFromString("http://example.com");
+		$newUri = $uri->withUserInfo("username", "password");
 
-        $this->assertEmpty($uri->getUserInfo());
-        $this->assertNotEquals($uri, $newUri);
-    }
+		$this->assertEmpty($uri->getUserInfo());
+		$this->assertNotEquals($uri, $newUri);
+	}
 
-    public function test_with_host_saves_data()
-    {
+	public function test_with_host_saves_data()
+	{
 		$uri = UriFactory::createFromString("http://example.com:80");
-        $uri = $uri->withHost("www.example.com");
-        $this->assertEquals("www.example.com", $uri->getHost());
-    }
+		$uri = $uri->withHost("www.example.com");
+		$this->assertEquals("www.example.com", $uri->getHost());
+	}
 
-    public function test_with_host_is_immutable()
-    {
-        $uri = UriFactory::createFromString("http://example.com");
-        $newUri = $uri->withHost("www.example.com");
+	public function test_with_host_is_immutable()
+	{
+		$uri = UriFactory::createFromString("http://example.com");
+		$newUri = $uri->withHost("www.example.com");
 
-        $this->assertNotEquals($uri, $newUri);
-    }
+		$this->assertNotEquals($uri, $newUri);
+	}
 
-    public function test_with_port_saves_data()
-    {
+	public function test_with_port_saves_data()
+	{
 		$uri = UriFactory::createFromString("http://example.com:80");
-        $uri = $uri->withPort(443);
-        $this->assertEquals(443, $uri->getPort());
-    }
+		$uri = $uri->withPort(443);
+		$this->assertEquals(443, $uri->getPort());
+	}
 
-    public function test_with_port_is_immutable()
-    {
-        $uri = UriFactory::createFromString("http://example.com");
-        $newUri = $uri->withPort(443);
+	public function test_with_port_is_immutable()
+	{
+		$uri = UriFactory::createFromString("http://example.com");
+		$newUri = $uri->withPort(443);
 
-        $this->assertEmpty($uri->getPort());
-        $this->assertNotEquals($uri, $newUri);
-    }
+		$this->assertEmpty($uri->getPort());
+		$this->assertNotEquals($uri, $newUri);
+	}
 
-    public function test_with_path_saves_data()
-    {
+	public function test_with_path_saves_data()
+	{
 		$uri = UriFactory::createFromString("http://example.com:80");
-        $uri = $uri->withPath("/some/path/to/resource");
-        $this->assertEquals("/some/path/to/resource", $uri->getPath());
-    }
+		$uri = $uri->withPath("/some/path/to/resource");
+		$this->assertEquals("/some/path/to/resource", $uri->getPath());
+	}
 
-    public function test_with_path_is_immutable()
-    {
-        $uri = UriFactory::createFromString("http://example.com:80");
-        $newUri = $uri->withPath("/some/path/to/resource");
+	public function test_with_path_is_immutable()
+	{
+		$uri = UriFactory::createFromString("http://example.com:80");
+		$newUri = $uri->withPath("/some/path/to/resource");
 
-        $this->assertEmpty($uri->getPath());
-        $this->assertNotEquals($uri, $newUri);
-    }
+		$this->assertEmpty($uri->getPath());
+		$this->assertNotEquals($uri, $newUri);
+	}
 
-    public function test_with_query_saves_data()
-    {
+	public function test_with_query_saves_data()
+	{
 		$uri = UriFactory::createFromString("http://example.com:80?q=foo&s=some search text");
-        $this->assertEquals("q=foo&s=some search text", $uri->getQuery());
-    }
+		$this->assertEquals("q=foo&s=some search text", $uri->getQuery());
+	}
 
-    public function test_with_query_is_immutable()
-    {
-        $uri = UriFactory::createFromString("http://example.com:80");
-        $newUri = $uri->withQuery("q=foo&s=some search text");
-
-        $this->assertEmpty($uri->getQuery());
-        $this->assertNotEquals($uri, $newUri);
-    }
-
-    public function test_with_fragment_saves_data()
-    {
+	public function test_with_query_is_immutable()
+	{
 		$uri = UriFactory::createFromString("http://example.com:80");
-        $uri = $uri->withFragment("Chapter1");
-        $this->assertEquals("Chapter1", $uri->getFragment());
-    }
+		$newUri = $uri->withQuery("q=foo&s=some search text");
 
-    public function test_with_fragment_is_immutable()
-    {
-        $uri = UriFactory::createFromString("http://example.com:80");
-        $newUri = $uri->withFragment("Chapter1");
+		$this->assertEmpty($uri->getQuery());
+		$this->assertNotEquals($uri, $newUri);
+	}
 
-        $this->assertEmpty($uri->getFragment());
-        $this->assertNotEquals($uri, $newUri);
-    }
-
-    public function test_get_authority_with_no_credentials_returns_empty_string()
-    {
+	public function test_with_fragment_saves_data()
+	{
 		$uri = UriFactory::createFromString("http://example.com:80");
-        $this->assertEquals("", $uri->getAuthority());
-    }
+		$uri = $uri->withFragment("Chapter1");
+		$this->assertEquals("Chapter1", $uri->getFragment());
+	}
+
+	public function test_with_fragment_is_immutable()
+	{
+		$uri = UriFactory::createFromString("http://example.com:80");
+		$newUri = $uri->withFragment("Chapter1");
+
+		$this->assertEmpty($uri->getFragment());
+		$this->assertNotEquals($uri, $newUri);
+	}
+
+	public function test_to_string(): void
+	{
+		$uri = new Uri("https", "example.com", "foo", 443, "username", "password", "a=value1&b=value2", "anchor1");
+
+		$this->assertEquals(
+			"https://username:password@example.com:443/foo?a=value1&b=value2#anchor1",
+			(string) $uri
+		);
+	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+require __DIR__ . "/../vendor/autoload.php";
+
+\error_reporting(E_ALL & ~E_WARNING);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,4 +2,8 @@
 
 require __DIR__ . "/../vendor/autoload.php";
 
+/**
+ * Disable warnings in order to test failed opening of files
+ * with \fopen().
+ */
 \error_reporting(E_ALL & ~E_WARNING);

--- a/tests/fixtures/test.json
+++ b/tests/fixtures/test.json
@@ -1,0 +1,1 @@
+{"name": "Test", "email": "test@example.com"}


### PR DESCRIPTION
# Features
* Support for PHP 8.x, leveraging features from 8.0
* Adding `createFromString` method in `StreamFactory`
* Adding `provide` property in composer file for `psr/http-message-implementation` and `psr/http-factory-implementation`.
* A lot of code and comment cleanup, standardizing formatting
* Stricter type hinting in constructors and methods where possible (using union type)

# Breaking changes
* Removing support for PHP 7.x
* Moving namespace to `Nimbly\Capsule`
* Removing warning suppression (`@`) when making calls to `fopen`