### PR TITLE
Fix tests on Windows

### DIFF
--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -92,7 +92,17 @@ class UploadedFileTest extends TestCase
 		$uploadedFile = $this->makeFile();
 
 		$this->expectException(RuntimeException::class);
-		$uploadedFile->moveTo("/root");
+
+		switch (PHP_OS) {
+			case 'WINNT':
+				$destination = 'C:\\';
+				break;
+
+			default:
+				$destination = '/root';
+		}
+
+		$uploadedFile->moveTo($destination);
 	}
 
 	public function test_calling_move_to_more_than_once_throws_exception(): void


### PR DESCRIPTION
the PR fixes:

```
$ vendor/bin/phpunit
Xdebug: [Step Debug] Time-out connecting to debugging client, waited: 200 ms. Tried: localhost:9000 (through xdebug.client_host/xdebug
.client_port).
PHPUnit 9.6.19 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.0
Configuration: K:\dev\github\php-nimbly-capsule\phpunit.xml

F..............................................................  63 / 178 ( 35%)
............................................................... 126 / 178 ( 70%)
....................................................            178 / 178 (100%)

Time: 00:00.150, Memory: 4.00 MB

There was 1 failure:

1) Nimbly\Capsule\Tests\UploadedFileTest::test_move_to_unwriteable_target_throws_runtime_exception
Failed asserting that exception of type "RuntimeException" is thrown.

FAILURES!
Tests: 178, Assertions: 262, Failures: 1.
```