### PR TITLE
Support http message 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": "^8.0",
-		"psr/http-message": "^1.0",
+		"psr/http-message": "^1.0|^2.0",
 		"psr/http-factory": "^1.0"
 	},
 	"provide": {


### PR DESCRIPTION
 Capsule needs http message version 1 which sometimes causes problems when the http message version is already set to 2.
This PR makes it possible to use both versions.